### PR TITLE
Update const_rgx pattern to match pylint 1.3

### DIFF
--- a/pylint_django/common.py
+++ b/pylint_django/common.py
@@ -18,7 +18,6 @@ def register(linter):
     name_checker.config.good_names += ('qs',)
     # Default pylint.checkers.base.CONST_NAME_RGX = re.compile('(([A-Z_][A-Z0-9_]*)|(__.*__))$').
     const_rgx = '%s|(urls|urlpatterns|register)%s' % (name_checker.config.const_rgx.pattern[:-2], name_checker.config.const_rgx.pattern[-2:])
-
     name_checker.config.const_rgx = re.compile(const_rgx)
 
     # we don't care about South migrations


### PR DESCRIPTION
New default value for `pylint.checkers.base.CONST_NAME_RGX = re.compile('(([A-Z_][A-Z0-9_]*)|(__.*__))$')` so additional pylint-django pattern should be inserted befere ")$".
