### PR TITLE
Remove spurious super on an old stlye class errors on Models

### DIFF
--- a/pylint_django/transforms/transforms/django_db_models.py
+++ b/pylint_django/transforms/transforms/django_db_models.py
@@ -1,4 +1,4 @@
-class Model:
+class Model(object):
     _meta = None
     objects = None
 


### PR DESCRIPTION
Ever since I started using pylint-django, I started getting these error message whenever using super(DerivedModel, self).anything() on classes that derive from the Django model class.

apps/accts/models/invitation.py:116: [E1002(super-on-old-class), Invitation.save] Use of super on an old style class

This pull request fixes this.
