### PR TITLE
Add content field to WSGIRequest proxy

### DIFF
--- a/pylint_django/transforms/transforms/django_core_handlers_wsgi.py
+++ b/pylint_django/transforms/transforms/django_core_handlers_wsgi.py
@@ -3,3 +3,4 @@ from django.core.handlers.wsgi import WSGIRequest as WSGIRequestOriginal
 
 class WSGIRequest(WSGIRequestOriginal):
     status_code = None
+    content = ''


### PR DESCRIPTION
The replacement WSGIRequest class defines status_code, but does not define other fields. Our code uses request.content extensively, and we're getting a lot off errors like

```
apps/accts/tests/test_api.py:122: [E1103(maybe-no-member), OrganizationTestCase.test_user_stats] Instance of 'WSGIRequest' has no 'content' member (but some types could not be inferred)
```

This pull request adds a content field to the replacement WSGIRequest object.
