### PR TITLE
Fix handling decorator with no name

### DIFF
--- a/pylint_django/checkers/models.py
+++ b/pylint_django/checkers/models.py
@@ -78,7 +78,7 @@ class ModelChecker(BaseChecker):
         # see https://github.com/landscapeio/pylint-django/issues/10
         if node.decorators is not None:
             for decorator in node.decorators.nodes:
-                if decorator.name == 'python_2_unicode_compatible':
+                if getattr(decorator, 'name', None) == 'python_2_unicode_compatible':
                     return
 
         self.add_message('W%s01' % BASE_ID, args=node.name, node=node)


### PR DESCRIPTION
The following currently crashes pylint-django, because the Astroid CallFunc representing the decorator node has no name attribute:

```
from django.db import models

def foo(*args):
    def bar(model):
        return model

@foo('does not matter')
class TestModel(models.Model):
    pass
```

This pull request fixes that.
