### PR TITLE
Add methods and members to ManyToManyField

### DIFF
--- a/pylint_django/transforms/transforms/django_db_models_fields_related.py
+++ b/pylint_django/transforms/transforms/django_db_models_fields_related.py
@@ -5,3 +5,36 @@ from django.db.models.fields.related import ManyToManyField as ManyToManyFieldOr
 class ManyToManyField(ManyToManyFieldOriginal, QuerySet):
     def __init__(self, to, **kwargs):
         ManyToManyFieldOriginal.__init__(to, **kwargs)
+        self.model = None
+        self.query_field_name = ''
+        self.core_filters = {}
+        self.instance = None
+        self.symmetrical = None
+        self.source_field = None
+        self.source_field_name = ''
+        self.target_field_name = ''
+        self.reverse = None
+        self.through = None
+        self.prefetch_cache_name = None
+        self.related_val = None
+
+    def get_queryset(self):
+        pass
+
+    def get_prefetch_queryset(self, instances):
+        pass
+
+    def add(self, *objs):
+        pass
+
+    def create(self, **kwargs):
+        pass
+
+    def get_or_create(self, **kwargs):
+        pass
+
+    def remove(self, *objs):
+        pass
+
+    def clear(self):
+        pass


### PR DESCRIPTION
My code uses some methods and members on ManyToMany fields that pylint-django doesn't represent in the transformed class. This pull request adds those and more.

I most care about add(), clear() and through existing.

However, I went into Django source code at https://github.com/django/django/blob/1.7/django/db/models/fields/related.py and extracted all the public methods and members from the dynamically generated ManyRelatedManager, only omitting those members/methods which overlapped with those in QuerySet which is already inherited from.

This solves my problem, but does have the potential of being problematic for these reasons:
- Since the fields are returning None and no method bodies exist, the type inference in pylint may end up incorrect. I think this precedent has been set by the other transformations.
- get_queryset and get_prefetch_queryset have different name get_query_set/get_prefetch_query_set in the Django 1.5 series and earlier. For now, I've just assumed 1.6+ compatibility.
- add() and remove() may not exist for ManyToMany fields "if the ManyToMany relation has an intermediary model" in Django 1.6 series and below. I think this is okay because in 1.7 the methods always exist but raise exceptions if called in those situations; however 1.6 and earlier code may end up with false negatives if analyzing code that attempts to call add() and remove() where this situation applies.
