### PR TITLE
augmentation: use ScopeConsumer instead an array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ _classifiers = (
 
 _install_requires = [
     'pylint-plugin-utils>=0.2.1',
-    'pylint>=1.8'
+    'pylint>=1.8.2'
 ]
 
 


### PR DESCRIPTION
PyCQA/pylint@d343169c0ca9abd37f8000c37b4dd35a9dfe6ab5 had introduced
NamesConsumerAtomic (renamed in ScopeConsumer in
PyCQA/pylint@b80d76d76e0be6ae14001a06c1b03fddc1c0f2fe).

ref https://github.com/PyCQA/pylint/commit/d343169c0ca9abd37f8000c37b4dd35a9dfe6ab5
ref https://github.com/codacy/codacy-pylint/pull/29
fix #120