### PR TITLE
Add Tox configuration, use Tox on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,33 @@
-sudo: false
 language: python
 python:
-  - "3.5"
-  - "3.6"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 env:
-  - DJANGO="1.11,<2.0"
-  - DJANGO="2.0,<3.0"
+  - DJANGO=1.11
+  - DJANGO=2.0
+matrix:
+  exclude:
+    # Python/Django combinations that aren't officially supported
+    - { python: 2.7, env: DJANGO=2.0 }
+  include:
+    - { python: 3.6, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=pylint }
+    - { python: 3.6, env: TOXENV=readme }
+  allow_failures:
+    - env: TOXENV=flake8
+    - env: TOXENV=pylint
+    - python: 2.7
 
 install:
-  - pip install coverage coveralls djangorestframework psycopg2 django-tables2
-  - pip install pylint-plugin-utils "Django>=$DJANGO"
+  - pip install tox-travis
 script:
-  - PYTHONPATH=. coverage run test/test_func.py
+  - tox
+
 after_success:
-  coveralls
+  - pip install coveralls
+  - coveralls
 notifications:
   email:
     on_failure: change

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 * [smirolo](https://github.com/smirolo)
 * [mbertolacci](https://github.com/mbertolacci)
 * [atodorov](https://github.com/atodorov)
+* [bittner](https://github.com/bittner)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,47 @@
+# This configuration file is for Tox. https://tox.readthedocs.io/
+# It houses configuration sections for common Python tools, too.
+
+[tox]
+envlist =
+    flake8
+    pylint
+    readme
+    py{27,34,35,36}-django111
+    py{34,35,36}-django20
+
+[testenv]
+commands =
+    flake8: flake8
+    pylint: pylint --rcfile=tox.ini pylint_django setup
+    readme: python setup.py check --restructuredtext --strict
+    py{27,34,35,36}-django{111,20}: coverage run test/test_func.py
+    clean: find . -type f -name '*.pyc' -delete
+    clean: find . -type d -name __pycache__ -delete
+    clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
+deps =
+    flake8: flake8
+    pylint: pylint
+    pylint: Django>=2.0,<2.1
+    readme: readme_renderer
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
+    py{27,34,35,36}: coverage
+    py{27,34,35,36}: djangorestframework
+    py{27,34,35,36}: psycopg2
+    py{27,34,35,36}: django-tables2
+    py{27,34,35,36}: pylint-plugin-utils
+    py{27,34,35,36}: pytest
+setenv =
+    PIP_DISABLE_PIP_VERSION_CHECK = 1
+    PYTHONPATH = .
+whitelist_externals =
+    clean: find
+    clean: rm
+
+[travis:env]
+DJANGO =
+    1.11: django111
+    2.0: django20
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
This PR adds a Tox configuration to the project to help keeping code quality stable.

The Travis setup is adapted accordingly: `tox` is used to run all linting and tests also on Travis CI.