### PR TITLE
Add missing test/input/func_model_does_not_use_unicode_py33.txt in the MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include pylint_django/transforms/transforms/*
-include test/input/func_model_does_not_use_unicode_py33.txt
+include test/input/*.txt test/input/*.rc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include pylint_django/transforms/transforms/*
+include test/input/func_model_does_not_use_unicode_py33.txt


### PR DESCRIPTION
Hi,

Right now the file `test/input/func_model_does_not_use_unicode_py33.txt` is not present in the pypi distribution and as we switched the source to pypi when packaging for Debian, we end up with this error:

```
____________ test_everything[func_model_does_not_use_unicode_py33] _____________

test_file = <test_functional.FunctionalTestFile object at 0x7f2b78ec3438>

    @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
    def test_everything(test_file):
        # copied from pylint.tests.test_functional.test_functional
        LintTest = PylintDjangoLintModuleTest(test_file)
        LintTest.setUp()
>       LintTest._runTest()

test/test_func.py:43:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.6/dist-packages/pylint/test/test_functional.py:308: in _runTest
    expected_messages, expected_text = self._get_expected()
/usr/local/lib/python3.6/dist-packages/pylint/test/test_functional.py:289: in _get_expected
    with self._open_expected_file() as fobj:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test.test_func.PylintDjangoLintModuleTest object at 0x7f2b77f55f28>

    def _open_expected_file(self):
>       return open(self._test_file.expected_output)
E       FileNotFoundError: [Errno 2] No such file or directory: '/tmp/autopkgtest.FOBT3E/build.TBr/src/test/input/func_model_does_not_use_unicode_py33.txt'

/usr/local/lib/python3.6/dist-packages/pylint/test/test_functional.py:276: FileNotFoundError
```

This PR adds the missing text file in the MANIFEST.in.

Thanks for your help!
Joseph