### PR TITLE
List Django as a dependency. Fix #96

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,33 @@ pylint-django
 
 `pylint-django` is a [Pylint](http://pylint.org) plugin for improving code analysis for when analysing code using Django. It is also used by the [Prospector](https://github.com/landscapeio/prospector) tool.
 
-## Usage
+# Installation
 
-#### Pylint
+```
+pip install pylint-django
+```
 
-Ensure `pylint-django` is installed and on your path (`pip install pylint-django`), and then run pylint:
+**WARNING:** `pylint-django` requires `Django` to be installed. Our `setup.py` file doesn't
+specify which particular version of Django is going to be installed because we have no idea
+what version is used inside your project. The latest version of Django will be installed if
+it has not been installed beforehand! DO NOT report issues about mismatching Django versions
+if that happens. Instead get your testing environment sorted out and make sure that you have
+the appropriate version of Django installed!
+
+# Usage
+
+## Pylint
+
+Ensure `pylint-django` is installed and on your path and then execute:
 
 ```
 pylint --load-plugins pylint_django [..other options..]
 ```
 
-#### Prospector
+## Prospector
 
-If you have `prospector` installed, then `pylint-django` will already be installed as a dependency, and will be activated automatically if Django is detected.
+If you have `prospector` installed, then `pylint-django` will already be installed as a dependency,
+and will be activated automatically if Django is detected.
 
 ```
 prospector [..other options..]
@@ -42,14 +56,14 @@ Please feel free to add your name to the `CONTRIBUTORS.md` file if you want to b
 credited when pull requests get merged. You can also add to the `CHANGELOG.md` file
 if you wish, although I'll also do that when merging if not.
 
-## Tests
+# Tests
 
 The structure of the test package follows that from pylint itself.
 
 It is fairly simple: create a module starting with `func_` followed by
 a test name, and insert into it some code. The tests will run pylint
- against these modules. If the idea is that no messages now occur, then
- that is fine, just check to see if it works by running `scripts/test.sh`.
+against these modules. If the idea is that no messages now occur, then
+that is fine, just check to see if it works by running `scripts/test.sh`.
 
 Ideally, add some pylint error suppression messages to the file to prevent
 spurious warnings, since these are all tiny little modules not designed to

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     install_requires=[
         'pylint-plugin-utils>=0.2.1',
         'pylint>=1.8.2',
+        'Django',
     ],
     license='GPLv2',
     classifiers=[


### PR DESCRIPTION
also add a big warning statement about possible side effects and to deter people from reporting issues about Django version mismatches. Updates README formatting a bit as well.

@jakirkham this should fix #96.

@carlio I've read your reasoning about not listing this as a dependency and the side effects it may have. Let's see if the warning text I've added has any effect. If we start seeing consistent reports about Django version mismatches I'm all for dropping the Django dependency from `setup.py` and adjusting the warning so that folks are aware they have to install Django explicitly.