### PR TITLE
Fix: compatibility with Python < 3.6

### DIFF
--- a/pylint_django/plugin.py
+++ b/pylint_django/plugin.py
@@ -28,7 +28,7 @@ def register(linter):
     try:
         from pylint_django.augmentations import apply_augmentations
         apply_augmentations(linter)
-    except ModuleNotFoundError:
+    except ImportError:
         # probably trying to execute pylint_django when Django isn't installed
         # in this case the django-not-installed checker will kick-in
         pass


### PR DESCRIPTION
ModuleNotFoundError is a subclass of ImportError, introduced in
Python 3.6, and as such fails in lower Python versions.

https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError