### PR TITLE
Suppress not-an-iterable for model_utils.managers. Fixes #117

### DIFF
--- a/pylint_django/tests/input/external_model_utils_noerror_override_manager.py
+++ b/pylint_django/tests/input/external_model_utils_noerror_override_manager.py
@@ -1,0 +1,26 @@
+# Check that when overriding the 'objects' attribite of a model class
+# with a manager from the django-model-utils package pylint-django
+# does not report not-an-iterator error
+# pylint: disable=missing-docstring
+
+from model_utils.managers import InheritanceManager
+
+from django.db import models
+
+
+class BaseModel(models.Model):
+    name = models.CharField()
+
+
+class BuggyModel(models.Model):
+    objects = InheritanceManager()
+
+    name = models.CharField()
+
+
+def function():
+    for record in BaseModel.objects.all():
+        print(record.name)
+
+    for record in BuggyModel.objects.all():
+        print(record.name)

--- a/pylint_django/tests/input/external_model_utils_noerror_override_manager.py
+++ b/pylint_django/tests/input/external_model_utils_noerror_override_manager.py
@@ -1,6 +1,7 @@
 # Check that when overriding the 'objects' attribite of a model class
 # with a manager from the django-model-utils package pylint-django
-# does not report not-an-iterator error
+# does not report not-an-iterator error, see
+# https://github.com/PyCQA/pylint-django/issues/117
 # pylint: disable=missing-docstring
 
 from model_utils.managers import InheritanceManager

--- a/pylint_django/tests/input/external_model_utils_noerror_override_manager.rc
+++ b/pylint_django/tests/input/external_model_utils_noerror_override_manager.rc
@@ -1,0 +1,2 @@
+[testoptions]
+requires = model_utils

--- a/pylint_django/tests/input/func_noerror_model_objects.py
+++ b/pylint_django/tests/input/func_noerror_model_objects.py
@@ -1,0 +1,20 @@
+# Test that defining `objects` as a regular model manager
+# doesn't raise issues, see
+# https://github.com/PyCQA/pylint-django/issues/144
+#
+# pylint: disable=missing-docstring
+
+from django.db import models
+
+
+class ModelWithRegularManager(models.Model):
+    objects = models.Manager()
+
+    name = models.CharField()
+
+
+def function():
+    record = ModelWithRegularManager.objects.all()[0]
+
+    for record in ModelWithRegularManager.objects.all():
+        print(record.name)

--- a/pylint_django/transforms/transforms/django_db_models.py
+++ b/pylint_django/transforms/transforms/django_db_models.py
@@ -7,6 +7,11 @@ def __noop(self, *args, **kwargs):
     return None
 
 
+def __noop_list(self, *args, **kwargs):
+    """Just a dumb no-op function to make code a bit more DRY"""
+    return []
+
+
 class Model(object):
     _meta = None
     objects = None
@@ -26,7 +31,7 @@ class Manager(object):
     """
     get_queryset = __noop
     none = __noop
-    all = __noop
+    all = __noop_list
     count = __noop
     dates = __noop
     distinct = __noop

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,9 @@ deps =
     django20: Django>=2.0,<2.1
     py{27,34,35,36}: coverage
     py{27,34,35,36}: djangorestframework
-    py{27,34,35,36}: psycopg2
+    py{27,34,35,36}: django-model-utils
     py{27,34,35,36}: django-tables2
+    py{27,34,35,36}: psycopg2
     py{27,34,35,36}: pylint-plugin-utils
     py{27,34,35,36}: pytest
 setenv =


### PR DESCRIPTION
I don't have experience with django-model-utils and I wasn't able to figure out why it produces this error. My search boiled down to `IterableChecker._check_iterable` inside pylint.  After executing `infered = safe_infered(node)` I get:

1) None when the code under evaluation is a standard Django objects manager
2) Const.NoneType(value=None) when inspecting the .all() of an InheritanceManager

Another possibility is to add a transformation similar to `pylint_django/transforms/transforms/django_db_models.py` which sets all of the same attributes of InheritanceManager (and friends).

In fact I think I may go ahead with the transformation option instead of this one. @carlio can I inherit the new transformation class from the above one or do I need to copy everything ?
