### PR TITLE
Fix explicit unicode check with python_2_unicode_compatible base models

### DIFF
--- a/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.py
+++ b/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.py
@@ -1,0 +1,19 @@
+"""
+Ensures that django models with a __str__ method defined in an ancestor and
+python_2_unicode_compatible decorator applied are flagged correctly as not
+having explicitly defined __unicode__
+"""
+#  pylint: disable=missing-docstring
+
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
+
+@python_2_unicode_compatible
+class BaseModel(models.Model):
+    def __str__(self):
+        return 'Foo'
+
+
+class SomeModel(BaseModel):  # [model-no-explicit-unicode]
+    pass

--- a/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.txt
+++ b/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.txt
@@ -1,0 +1,1 @@
+model-no-explicit-unicode:18:SomeModel:Model does not explicitly define __unicode__ (SomeModel)


### PR DESCRIPTION
This fixes the case where a `__unicode__` method is defined in a base class via the python_2_unicode_compatible decorator.

I'm a bit lost on how to add a test for this. I would appreciate any help.