### PR TITLE
Register transforms for FileField. Fix #60

### DIFF
--- a/pylint_django/tests/input/func_noerror_model_fields.py
+++ b/pylint_django/tests/input/func_noerror_model_fields.py
@@ -76,7 +76,9 @@ class LotsOfFieldsModel(models.Model):
         print(self.durationfield.total_seconds())
 
     def filefield_tests(self):
+        self.filefield.save('/dev/null', 'TEST')
         print(self.filefield.file)
+        self.imagefield.save('/dev/null', 'TEST')
         print(self.imagefield.file)
 
     def numberfield_tests(self):

--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -46,3 +46,5 @@ _add_transform('django.db.models',
                'Manager')
 _add_transform('django.utils.translation', 'ugettext_lazy')
 _add_transform('mongoengine', 'Document')
+# register transform for FileField/ImageField, see #60
+_add_transform('django.db.models.fields.files', 'FileField')


### PR DESCRIPTION
It turns out the existing transformations were not registered. Also add a test for #60.


@carlio from what I can see many of the existing transformations are not loaded using `_add_transform`. Can you quickly explain how is this part of the code supposed to run ? Should every transform be loaded manually in `__init__.py` or there's some way for them to be auto loaded ?