### PR TITLE
New checker pylint_django.checkers.db_performance. Fix #118

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,23 @@ Features
 * ``Meta`` informational classes on forms and models do not generate errors.
 
 
+Additional plugins
+------------------
+
+``pylint_django.checkers.db_performance`` looks for migrations which add new
+model fields and these fields have a default value. According to
+`Django docs <https://docs.djangoproject.com/en/2.0/topics/migrations/#postgresql>`__
+this may have performance penalties especially on large tables. The prefered way
+is to add a new DB column with ``null=True`` because it will be created instantly
+and then possibly populate the table with the desired default values.
+
+Only the last migration from a sub-directory will be examined!
+
+This plugin is disabled by default! To enable it::
+
+    pylint --load-plugins pylint_django --load-plugins pylint_django.checkers.db_performance
+
+
 Contributing
 ------------
 

--- a/pylint_django/checkers/db_performance.py
+++ b/pylint_django/checkers/db_performance.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2018 Alexander Todorov <atodorov@MrSenko.com>
+
+# Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint-django/blob/master/LICENSE
+"""
+Various DB performance suggestions. Disabled by default! Enable with
+pylint --load-plugins=pylint_django.checkers.db_performance
+"""
+
+import astroid
+
+from pylint import interfaces
+from pylint import checkers
+from pylint.checkers import utils
+from pylint_django.__pkginfo__ import BASE_ID
+
+
+def _is_addfield_with_default(call):
+    if not isinstance(call.func, astroid.Attribute):
+        return False
+
+    if not call.func.attrname == 'AddField':
+        return False
+
+    for keyword in call.keywords:
+        # looking for AddField(..., field=XXX(..., default=Y, ...), ...)
+        if keyword.arg == 'field' and isinstance(keyword.value, astroid.Call):
+            # loop over XXX's keywords
+            # NOTE: not checking if XXX is an actual field type because there could
+            # be many types we're not aware of. Also the migration will probably break
+            # if XXX doesn't instantiate a field object!
+            for field_keyword in keyword.value.keywords:
+                if field_keyword.arg == 'default':
+                    return True
+
+    return False
+
+
+def _is_migrations_module(node):
+    if not isinstance(node, astroid.Module):
+        return False
+
+    return 'migrations' in node.path and not node.path.endswith('__init__.py')
+
+
+class NewDbFieldWithDefaultChecker(checkers.BaseChecker):
+    """
+    Looks for migrations which add new model fields and these fields have a
+    default value. According to Django docs this may have performance penalties
+    especially on large tables:
+    https://docs.djangoproject.com/en/2.0/topics/migrations/#postgresql
+
+    The prefered way is to add a new DB column with null=True because it will
+    be created instantly and then possibly populate the table with the
+    desired default values.
+    """
+
+    __implements__ = (interfaces.IAstroidChecker,)
+
+    # configuration section name
+    name = 'new-db-field-with-default'
+    msgs = {'W%s98' % BASE_ID: ("%s AddField with default value",
+                                'new-db-field-with-default',
+                                'Used when Pylint detects migrations adding new '
+                                'fields with a default value.')}
+
+    _migration_modules = []
+    _possible_offences = {}
+
+    def visit_module(self, node):
+        if _is_migrations_module(node):
+            self._migration_modules.append(node)
+
+    def visit_call(self, node):
+        try:
+            module = node.frame().parent
+        except:  # noqa: E722, pylint: disable=bare-except
+            return
+
+        if not _is_migrations_module(module):
+            return
+
+        if _is_addfield_with_default(node):
+            if module not in self._possible_offences:
+                self._possible_offences[module] = []
+
+            if node not in self._possible_offences[module]:
+                self._possible_offences[module].append(node)
+
+    @utils.check_messages('new-db-field-with-default')
+    def close(self):
+        def _path(node):
+            return node.path
+
+        # sort all migrations by name in reverse order b/c
+        # we need only the latest ones
+        self._migration_modules.sort(key=_path, reverse=True)
+
+        # filter out the last migration modules under each distinct
+        # migrations directory, iow leave only the latest migrations
+        # for each application
+        last_name_space = ''
+        latest_migrations = []
+        for module in self._migration_modules:
+            name_space = module.path.split('migrations')[0]
+            if name_space != last_name_space:
+                last_name_space = name_space
+                latest_migrations.append(module)
+
+        for module, nodes in self._possible_offences.items():
+            if module in latest_migrations:
+                for node in nodes:
+                    self.add_message('new-db-field-with-default', args=module.name, node=node)
+
+
+def register(linter):
+    """Required method to auto register this checker."""
+    # don't blacklist migrations for this checker
+    new_black_list = list(linter.config.black_list)
+    new_black_list.remove('migrations')
+    linter.config.black_list = new_black_list
+
+    linter.register_checker(NewDbFieldWithDefaultChecker(linter))

--- a/pylint_django/tests/input/migrations/0001_noerror_initial.py
+++ b/pylint_django/tests/input/migrations/0001_noerror_initial.py
@@ -1,0 +1,19 @@
+"""
+Initial migration which should not raise any pylint warnings.
+"""
+# pylint: disable=missing-docstring, invalid-name
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='TestRun',
+            fields=[
+                ('id', models.AutoField(serialize=False, primary_key=True)),
+                ('summary', models.TextField()),
+                ('environment_id', models.IntegerField(default=0)),
+                ('auto_update_run_status', models.BooleanField(default=False)),
+            ],
+        ),
+    ]

--- a/pylint_django/tests/input/migrations/0002_new_column.py
+++ b/pylint_django/tests/input/migrations/0002_new_column.py
@@ -1,0 +1,33 @@
+"""
+Migration file which adds a new column with a default value.
+This should trigger a warning because adding new columns with
+default value on a large table leads to DB performance issues.
+
+See:
+https://github.com/PyCQA/pylint-django/issues/118 and
+https://docs.djangoproject.com/en/2.0/topics/migrations/#postgresql
+
+> ... adding columns with default values will cause a full rewrite of
+> the table, for a time proportional to its size.
+> For this reason, it’s recommended you always create new columns with
+> null=True, as this way they will be added immediately.
+"""
+# pylint: disable=missing-docstring, invalid-name
+from datetime import timedelta
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('input', '0001_noerror_initial'),
+    ]
+
+    operations = [
+        # add a timedelta field
+        migrations.AddField(  # [new-db-field-with-default]
+            model_name='testrun',
+            name='estimated_time',
+            field=models.DurationField(default=timedelta(0)),
+        ),
+    ]

--- a/pylint_django/tests/input/migrations/0002_new_column.txt
+++ b/pylint_django/tests/input/migrations/0002_new_column.txt
@@ -1,0 +1,1 @@
+new-db-field-with-default:28:Migration:migrations.0002_new_column AddField with default value

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -11,6 +11,8 @@ import test_functional  # noqa: E402
 # alter sys.path again because the tests now live as a subdirectory
 # of pylint_django
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+# so we can find migrations
+sys.path.append(os.path.join(os.path.dirname(__file__), 'input'))
 
 
 class PylintDjangoLintModuleTest(test_functional.LintModuleTest):
@@ -22,14 +24,34 @@ class PylintDjangoLintModuleTest(test_functional.LintModuleTest):
         self._linter.load_plugin_modules(['pylint_django'])
 
 
-def get_tests():
+class PylintDjangoDbPerformanceTest(PylintDjangoLintModuleTest):
+    """
+        Only used so that we can load
+        pylint_django.checkers.db_performance into the linter!
+    """
+    def __init__(self, test_file):
+        super(PylintDjangoDbPerformanceTest, self).__init__(test_file)
+        self._linter.load_plugin_modules(['pylint_django.checkers.db_performance'])
+
+
+def get_tests(input_dir='input', sort=False):
+    def _file_name(test):
+        return test.base
+
     HERE = os.path.dirname(os.path.abspath(__file__))
-    input_dir = os.path.join(HERE, 'input')
+    input_dir = os.path.join(HERE, input_dir)
 
     suite = []
     for fname in os.listdir(input_dir):
         if fname != '__init__.py' and fname.endswith('.py'):
             suite.append(test_functional.FunctionalTestFile(input_dir, fname))
+
+    # when testing the db_performance plugin we need to sort by input file name
+    # because the plugin reports the errors in close() which appends them to the
+    # report for the last file in the list
+    if sort:
+        suite.sort(key=_file_name)
+
     return suite
 
 
@@ -41,6 +63,18 @@ TESTS_NAMES = [t.base for t in TESTS]
 def test_everything(test_file):
     # copied from pylint.tests.test_functional.test_functional
     LintTest = PylintDjangoLintModuleTest(test_file)
+    LintTest.setUp()
+    LintTest._runTest()
+
+
+# NOTE: define tests for the db_performance checker!
+DB_PERFORMANCE_TESTS = get_tests('input/migrations', True)
+DB_PERFORMANCE_TESTS_NAMES = [t.base for t in DB_PERFORMANCE_TESTS]
+
+
+@pytest.mark.parametrize("test_file", DB_PERFORMANCE_TESTS, ids=DB_PERFORMANCE_TESTS_NAMES)
+def test_db_performance_plugin(test_file):
+    LintTest = PylintDjangoDbPerformanceTest(test_file)
     LintTest.setUp()
     LintTest._runTest()
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python pylint_django/tests/test_func.py
+python pylint_django/tests/test_func.py -v

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
     flake8: flake8
     pylint: pylint --rcfile=tox.ini -d missing-docstring --ignore=tests pylint_django setup
     readme: python setup.py check --restructuredtext --strict
-    py{27,34,35,36}-django{111,20}: coverage run pylint_django/tests/test_func.py
+    py{27,34,35,36}-django{111,20}: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/


### PR DESCRIPTION
Enables checking of migrations and reports when there's an
AddField with a default value which may slow down applying
migrations on large tables. This may also lead to production tables
being locked while migrations are being applied.

@chukkwagon can you give this a try ?

I'm planning to merge all currently open PRs and release a 0.10.0 version next Tuesday.