### PR TITLE
Remove legacy check from ModelChecker

### DIFF
--- a/pylint_django/checkers/models.py
+++ b/pylint_django/checkers/models.py
@@ -6,7 +6,6 @@ from astroid.nodes import ClassDef, FunctionDef, AssignName
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers.utils import check_messages
 from pylint.checkers import BaseChecker
-from pylint.__pkginfo__ import numversion as PYLINT_VERSION
 
 from pylint_django.__pkginfo__ import BASE_ID
 from pylint_django.utils import node_is_subclass, PY3
@@ -76,19 +75,8 @@ class ModelChecker(BaseChecker):
     name = 'django-model-checker'
     msgs = MESSAGES
 
-    # NOTE: there's a bug in pylint's backwards compatability logic after changing
-    # visit method names from visit_class to visit_classdef, see
-    # https://bitbucket.org/logilab/pylint/issues/711/new-node-visit-methods-not-backwards
-    if PYLINT_VERSION < (1, 5):
-        @check_messages('model-missing-unicode')
-        def visit_class(self, node):
-            return self._visit_classdef(node)
-    else:
-        @check_messages('model-missing-unicode')
-        def visit_classdef(self, node):
-            return self._visit_classdef(node)
-
-    def _visit_classdef(self, node):
+    @check_messages('model-missing-unicode')
+    def visit_classdef(self, node):
         """Class visitor."""
         if not node_is_subclass(node, 'django.db.models.base.Model', '.Model'):
             # we only care about models


### PR DESCRIPTION
The minimum Pylint version is now 1.8.2 as mentioned [here](https://github.com/PyCQA/pylint-django/pull/169#discussion_r198727205), so this check is no longer necessary.