### PR TITLE
Upgrading pylint-plugin-utils version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'pylint-plugin-utils>=0.2.1',
+        'pylint-plugin-utils>=0.3',
         'pylint>=1.8.2',
     ],
     extras_require={


### PR DESCRIPTION
I created a new version of pylint-plugin-utils. There are no functional changes - you can see the commits yourself.

Differences now which might impact pylint-django:
  1) Python2 is dropped (which is already true for pylint and pylint-django anyway)
  2) astroid is no longer a direct dependency (which pylint pulls in anyway).

I don't think there will be any problems as the changes are minor.