### PR TITLE
WIP: QuerySet Inference

### DIFF
--- a/pylint_django/tests/input/func_noerror_managers_return_querysets.py
+++ b/pylint_django/tests/input/func_noerror_managers_return_querysets.py
@@ -1,0 +1,50 @@
+"""
+Checks that Pylint does not complain about Manager methods returning lists
+when they in fact return QuerySets
+"""
+
+from django.db import models
+
+class SomeModelQuerySet(models.QuerySet):
+    """ A missing docstring """
+    @staticmethod
+    def public_method():
+        """ A missing docstring """
+        return 1
+
+
+class SomeModelManager(models.Manager):
+    """A missing docstring"""
+
+    @staticmethod
+    def public_method():
+        """ A missing docstring """
+        return 1
+
+    @staticmethod
+    def another_public_method():
+        """ A missing docstring """
+        return 1
+
+
+class SomeModel(models.Model):
+    """ A missing docstring """
+
+    name = models.CharField(max_length=20)
+    datetimestamp = models.DateTimeField()
+
+    objects = SomeModelManager()
+
+
+class OtherModel(models.Model):
+    """ A missing docstring """
+
+    name = models.CharField(max_length=20)
+    somemodel = models.ForeignKey(SomeModel, on_delete=models.CASCADE, null=False)
+
+
+def call_some_querysets():
+    """ A missing docstring """
+
+    not_a_list = SomeModel.objects.filter()
+    not_a_list.values_list('id', flat=True)

--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -6,11 +6,12 @@ from astroid import MANAGER
 from astroid.builder import AstroidBuilder
 from astroid import nodes
 
-from pylint_django.transforms import foreignkey, fields
+from pylint_django.transforms import foreignkey, fields, queryset
 
 
 foreignkey.add_transform(MANAGER)
 fields.add_transforms(MANAGER)
+queryset.add_transforms(MANAGER)
 
 
 def _add_transform(package_name, *class_names):

--- a/pylint_django/transforms/queryset.py
+++ b/pylint_django/transforms/queryset.py
@@ -4,14 +4,20 @@ from astroid.nodes import Attribute
 from pylint_django import utils
 
 
-def is_queryset_producing_call(node):
+# function calls of a django.db.models.Manager that return a django.db.models.QuerySet
+QUERYSET_FUNCS = (
+    'get_queryset',
+    'filter',
+    'all',
+)
 
-    func_name = None
+
+def is_queryset_producing_call(node):
 
     if isinstance(node.func, Attribute):
         # TODO here, tis currently identifies ANY attribute named 'filter'
         # not just the one on Managers/QuerySets
-        if node.func.attrname == 'filter':
+        if node.func.attrname in QUERYSET_FUNCS:
             return True
 
     return False
@@ -30,6 +36,6 @@ def infer_queryset(call_node, context=None):
 
 def add_transforms(manager):
 
-    manager.register_transform(nodes.Call, # maybe could use nodes.CallFunc?
+    manager.register_transform(nodes.Call,
                                inference_tip(infer_queryset),
                                is_queryset_producing_call)

--- a/pylint_django/transforms/queryset.py
+++ b/pylint_django/transforms/queryset.py
@@ -1,0 +1,35 @@
+from astroid import MANAGER, nodes, inference_tip
+from astroid.nodes import Attribute
+
+from pylint_django import utils
+
+
+def is_queryset_producing_call(node):
+
+    func_name = None
+
+    if isinstance(node.func, Attribute):
+        # TODO here, tis currently identifies ANY attribute named 'filter'
+        # not just the one on Managers/QuerySets
+        if node.func.attrname == 'filter':
+            return True
+
+    return False
+
+
+def infer_queryset(call_node, context=None):
+
+    base_nodes = MANAGER.ast_from_module_name('django.db.models.query').lookup('QuerySet')
+
+    if utils.PY3:
+        base_nodes = [n for n in base_nodes[1] if not isinstance(n, nodes.ImportFrom)]
+    else:
+        base_nodes = list(base_nodes[1])
+
+    return iter([node.instantiate_class() for node in base_nodes])
+
+def add_transforms(manager):
+
+    manager.register_transform(nodes.Call, # maybe could use nodes.CallFunc?
+                               inference_tip(infer_queryset),
+                               is_queryset_producing_call)


### PR DESCRIPTION
This is a rough implementation of a fix for #165.

I believe the issue is here: https://github.com/PyCQA/pylint-django/blob/master/pylint_django/transforms/transforms/django_db_models.py#L43, which causes pylint to infer that the return type of `objects.filter()` is a `list` instead of a `QuerySet`

I can see a couple of ways forward, some of which are called out in the linked issue:
1. Add another stubbed out `QuerySet` similar to the defined `Manager` in `django_db_models.py`
2. Help pylint infer the return types of Manager methods
3. Revisit the problems with import Django itself and allowing pylint to infer the actual classes themselves

I've opted to try to implement 2, however I can see it's missing two key things:
1. Specific detection and restriction of the type the `QuerySet` returning functions are called on. (namely it needs to be only QuerySets and Managers)
2. Since it infers the type as the generic `QuerySet`, it is still missing the custom methods defined on the specific `ModelQuerySet`

If someone could point me in the right direction I would appreciate it