### PR TITLE
Another take on compatibility

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,5 @@
 * [atodorov](https://github.com/atodorov)
 * [bittner](https://github.com/bittner)
 * [federicobond](https://github.com/federicobond)
+* [clintonb](https://github.com/clintonb)
+

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ If it's just done for convenience that's really up to you the developer to fix.
 Contributing
 ------------
 
-Please feel free to add your name to the ``CONTRIBUTORS.rst`` file if you want to
+Please feel free to add your name to the ``CONTRIBUTORS.md`` file if you want to
 be credited when pull requests get merged. You can also add to the
 ``CHANGELOG.rst`` file if you wish, although we'll also do that when merging.
 

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -10,7 +10,6 @@ from astroid.scoped_nodes import ClassDef as ScopedClass, Module
 from pylint.checkers.base import DocStringChecker, NameChecker
 from pylint.checkers.design_analysis import MisdesignChecker
 from pylint.checkers.classes import ClassChecker
-from pylint.checkers.newstyle import NewStyleConflictChecker
 from pylint.checkers.variables import VariablesChecker
 from pylint.checkers.typecheck import TypeChecker
 from pylint.checkers.variables import ScopeConsumer
@@ -787,7 +786,6 @@ def apply_augmentations(linter):
 
     # Meta
     suppress_message(linter, DocStringChecker.visit_classdef, 'missing-docstring', is_model_meta_subclass)
-    suppress_message(linter, NewStyleConflictChecker.visit_classdef, 'old-style-class', is_model_meta_subclass)
     suppress_message(linter, ClassChecker.visit_classdef, 'no-init', is_model_meta_subclass)
     suppress_message(linter, MisdesignChecker.leave_classdef, 'too-few-public-methods', is_model_meta_subclass)
     suppress_message(linter, ClassChecker.visit_attribute, 'protected-access', allow_meta_protected_access)
@@ -795,7 +793,6 @@ def apply_augmentations(linter):
     # Media
     suppress_message(linter, NameChecker.visit_assignname, 'C0103', is_model_media_valid_attributes)
     suppress_message(linter, DocStringChecker.visit_classdef, 'missing-docstring', is_model_media_subclass)
-    suppress_message(linter, NewStyleConflictChecker.visit_classdef, 'old-style-class', is_model_media_subclass)
     suppress_message(linter, ClassChecker.visit_classdef, 'no-init', is_model_media_subclass)
     suppress_message(linter, MisdesignChecker.leave_classdef, 'too-few-public-methods', is_model_media_subclass)
 
@@ -823,7 +820,6 @@ def apply_augmentations(linter):
 
     # django-mptt
     suppress_message(linter, DocStringChecker.visit_classdef, 'missing-docstring', is_model_mpttmeta_subclass)
-    suppress_message(linter, NewStyleConflictChecker.visit_classdef, 'old-style-class', is_model_mpttmeta_subclass)
     suppress_message(linter, ClassChecker.visit_classdef, 'W0232', is_model_mpttmeta_subclass)
     suppress_message(linter, MisdesignChecker.leave_classdef, 'too-few-public-methods', is_model_mpttmeta_subclass)
 

--- a/pylint_django/tests/input/func_noerror_test_wsgi_request.py
+++ b/pylint_django/tests/input/func_noerror_test_wsgi_request.py
@@ -9,7 +9,6 @@ from django.db import models
 
 class SomeModel(models.Model):
     """Just a model."""
-    pass
 
 
 class SomeTestCase(TestCase):

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -1,7 +1,7 @@
 """Utils."""
 import sys
 
-from astroid.util import Uninferable 
+from astroid.util import Uninferable
 from astroid.bases import Instance
 from astroid.nodes import ClassDef
 from astroid.exceptions import InferenceError

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -1,7 +1,7 @@
 """Utils."""
 import sys
 
-from astroid.util import YES
+from astroid.util import Uninferable 
 from astroid.bases import Instance
 from astroid.nodes import ClassDef
 from astroid.exceptions import InferenceError
@@ -15,7 +15,7 @@ def node_is_subclass(cls, *subclass_names):
     if not isinstance(cls, (ClassDef, Instance)):
         return False
 
-    if cls.bases == YES:
+    if cls.bases == Uninferable:
         return False
     for base_cls in cls.bases:
         try:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pylint-plugin-utils>=0.4',
-        'pylint>=2.0',
+        'pylint>=2.2',
     ],
     extras_require={
         'with_django': ['Django'],


### PR DESCRIPTION
@carlio here's another approach for the recent issues.

Basically my argument is that we don't need the compatibility layer, instead we need to properly annotate what kind of pylint versions we require. 

I am more in favor of investing the time to use tools like PyUP.io which will automatically monitor for dependencies and start tests/pull requests or even designing our suite in Travis to execute regularly against the latest pylint/astroid so we can get a fair warning when something is about to break.

If you like this approach we can release a 2.0.4 version which requires the older version of pylint/astroid then revert the compat layer again and merge these changes on top of that with a new version (2.2 to match pylint maybe? ).