### PR TITLE
Avoid traceback with concurrent execution. Fixes #197

### DIFF
--- a/pylint_django/checkers/db_performance.py
+++ b/pylint_django/checkers/db_performance.py
@@ -117,7 +117,8 @@ def register(linter):
     """Required method to auto register this checker."""
     # don't blacklist migrations for this checker
     new_black_list = list(linter.config.black_list)
-    new_black_list.remove('migrations')
+    if 'migrations' in new_black_list:
+        new_black_list.remove('migrations')
     linter.config.black_list = new_black_list
 
     linter.register_checker(NewDbFieldWithDefaultChecker(linter))


### PR DESCRIPTION
when running `pylint --jobs 2` the behavior is probably somewhat
flaky but we can at least avoid crashing when the element is not
on the list