### PR TITLE
Add support for new load_configuration hook of pylint

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 * [atodorov](https://github.com/atodorov)
 * [bittner](https://github.com/bittner)
 * [federicobond](https://github.com/federicobond)
+* [matusvalo](https://github.com/matusvalo)

--- a/pylint_django/checkers/db_performance.py
+++ b/pylint_django/checkers/db_performance.py
@@ -13,6 +13,7 @@ from pylint import interfaces
 from pylint import checkers
 from pylint.checkers import utils
 from pylint_django.__pkginfo__ import BASE_ID
+from pylint_django import compat
 
 
 def _is_addfield_with_default(call):
@@ -113,12 +114,16 @@ class NewDbFieldWithDefaultChecker(checkers.BaseChecker):
                     self.add_message('new-db-field-with-default', args=module.name, node=node)
 
 
-def register(linter):
-    """Required method to auto register this checker."""
+def load_configuration(linter):
     # don't blacklist migrations for this checker
     new_black_list = list(linter.config.black_list)
     if 'migrations' in new_black_list:
         new_black_list.remove('migrations')
     linter.config.black_list = new_black_list
 
+
+def register(linter):
+    """Required method to auto register this checker."""
     linter.register_checker(NewDbFieldWithDefaultChecker(linter))
+    if not compat.LOAD_CONFIGURATION_SUPPORTED:
+        load_configuration(linter)

--- a/pylint_django/compat.py
+++ b/pylint_django/compat.py
@@ -22,3 +22,7 @@ except ImportError:
     except ImportError:
         from astroid.util import Uninferable
 
+import pylint
+
+# pylint before version 2.3 does not support load_configuration() hook.
+LOAD_CONFIGURATION_SUPPORTED = pylint.__pkginfo__.numversion >= (2, 3)

--- a/pylint_django/plugin.py
+++ b/pylint_django/plugin.py
@@ -7,13 +7,12 @@ from pylint_django.checkers import register_checkers
 # we want to import the transforms to make sure they get added to the astroid manager,
 # however we don't actually access them directly, so we'll disable the warning
 from pylint_django import transforms  # noqa, pylint: disable=unused-import
+from pylint_django import compat
 
 
-def register(linter):
+def load_configuration(linter):
     """
-    Registering additional checkers.
-
-    However, we will also use it to amend existing checker config.
+    Amend existing checker config.
     """
     name_checker = get_checker(linter, NameChecker)
     name_checker.config.good_names += ('qs', 'urlpatterns', 'register', 'app_name', 'handler500')
@@ -21,6 +20,11 @@ def register(linter):
     # we don't care about South migrations
     linter.config.black_list += ('migrations', 'south_migrations')
 
+
+def register(linter):
+    """
+    Registering additional checkers.
+    """
     # add all of the checkers
     register_checkers(linter)
 
@@ -32,3 +36,6 @@ def register(linter):
         # probably trying to execute pylint_django when Django isn't installed
         # in this case the django-not-installed checker will kick-in
         pass
+
+    if not compat.LOAD_CONFIGURATION_SUPPORTED:
+        load_configuration(linter)


### PR DESCRIPTION
This PR adds new pylint hook `load_configuration()`. This hook serves for adjusting configuration of linter: http://pylint.pycqa.org/en/latest/how_tos/plugins.html

Closes #181 