### PR TITLE
Whitelist the coverage command in tox.ini to avoid some warnings.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ setenv =
 whitelist_externals =
     django_not_installed: bash
     readme: bash
+    py{36}-django{111,20,-master}: coverage
+    py{35,36,37}-django21: coverage
     clean: find
     clean: rm
 


### PR DESCRIPTION
This change gets rid of the following warning message in the travis builds for `py{36}-django{111,20,-master}` and `py{35,36,37}-django21`:
```
py37-django21 runtests: commands[0] | coverage run pylint_django/tests/test_func.py -v
WARNING: test command found but not installed in testenv
  cmd: /home/travis/virtualenv/python3.7-dev/bin/coverage
  env: /home/travis/build/PyCQA/pylint-django/.tox/py37-django21
```

It's just for cleanup purposes.

Thanks,
Joseph