### PR TITLE
Switch to twine in tox.ini as recommended to check the rst doc.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     django_is_installed: pylint --load-plugins=pylint_django setup.py
     flake8: flake8
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
-    readme: python setup.py check --restructuredtext --strict
+    readme: python setup.py -q sdist && twine check dist/*
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django21: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
@@ -28,7 +28,7 @@ deps =
     flake8: flake8
     pylint: pylint
     pylint: Django
-    readme: readme_renderer
+    readme: twine
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     django_is_installed: pylint --load-plugins=pylint_django setup.py
     flake8: flake8
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
-    readme: python setup.py -q sdist && twine check dist/*
+    readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django21: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
@@ -40,6 +40,7 @@ setenv =
     PYTHONPATH = .
 whitelist_externals =
     django_not_installed: bash
+    readme: bash
     clean: find
     clean: rm
 


### PR DESCRIPTION
When running the readme and sanity targets you can see the following message:

```
readme runtests: commands[0] | python setup.py check --restructuredtext --strict
running check
warning: Check: This command has been deprecated. Use `twine check` instead: https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup
The project's long description is valid RST.
```

This PR switches the check to twine as recommended.