### PR TITLE
Fixed AstroidImportError

### DIFF
--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -1,6 +1,7 @@
-import sys
-
-from astroid import MANAGER, scoped_nodes, nodes, inference_tip
+from astroid import (
+    MANAGER, scoped_nodes, nodes, inference_tip,
+    AstroidImportError
+)
 
 from pylint_django import utils
 
@@ -39,11 +40,10 @@ def apply_type_shim(cls, _context=None):  # noqa
     elif cls.name == 'FloatField':
         base_nodes = scoped_nodes.builtin_lookup('float')
     elif cls.name == 'DecimalField':
-        if sys.version_info >= (3, 5):
-            # I dunno, I'm tired and this works :(
+        try:
             base_nodes = MANAGER.ast_from_module_name('_decimal').lookup('Decimal')
-        else:
-            base_nodes = MANAGER.ast_from_module_name('decimal').lookup('Decimal')
+        except AstroidImportError:
+            base_nodes = MANAGER.ast_from_module_name('_pydecimal').lookup('Decimal')
     elif cls.name in ('SplitDateTimeField', 'DateTimeField'):
         base_nodes = MANAGER.ast_from_module_name('datetime').lookup('datetime')
     elif cls.name == 'TimeField':


### PR DESCRIPTION
Astroid raises import error because can't find `_decimal`
CPython `decimal.py` resolves import by yourself using ImportError exception handler inside.

![image](https://user-images.githubusercontent.com/4462103/53465997-ce7ab180-3a9b-11e9-9194-9afe435245b8.png)
