### PR TITLE
Add load_configuration() in pylint_django.__init__. Fixes #222

### DIFF
--- a/pylint_django/__init__.py
+++ b/pylint_django/__init__.py
@@ -10,3 +10,4 @@ if sys.version_info < (3, ):
                              "Please migrate to Python 3!")
 
 register = plugin.register  # pylint: disable=invalid-name
+load_configuration = plugin.load_configuration  # pylint: disable=invalid-name


### PR DESCRIPTION
If you invoke the plugin like so:

pylint --load-plugins pylint_django.plugin configuration is applied

this patch makes it possible to invoke it also like this:

pylint --load-plugins pylint_django

which is more common.