### PR TITLE
Bugfix: Use functools.wrap to preserve leave_module info

### DIFF
--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -1,5 +1,6 @@
 """Augmentations."""
 #  pylint: disable=invalid-name
+import functools
 import itertools
 
 from astroid import InferenceError
@@ -737,6 +738,7 @@ def is_class(class_name):
 
 
 def wrap(orig_method, with_method):
+    @functools.wraps(orig_method)
     def wrap_func(*args, **kwargs):
         with_method(orig_method, *args, **kwargs)
     return wrap_func


### PR DESCRIPTION
Since pylint-plugin-utils's `augment_visit` was using checker_methods `__module__` and `__qualname__` to get the checker [visit_augment](https://github.com/PyCQA/pylint-plugin-utils/blob/43fde2104fb4e7d6aa3a6a71725bca31d44eb936/pylint_plugin_utils/__init__.py#L50) this information was lost after decorating the `leave_module` [wrap](https://github.com/PyCQA/pylint-django/blob/master/pylint_django/augmentations/__init__.py#L846) and the checker and hence it was throwing exception.