### PR TITLE
Suppress no-member for ManyToManyField. Fixes #192 #237

### DIFF
--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -248,6 +248,8 @@ MANYTOMANY_FIELD_ATTRS = {
     'clear',
     'related_name',
     'related_query_name',
+    'remove',
+    'set',
     'limit_choices_to',
     'symmetrical',
     'through',

--- a/pylint_django/tests/input/func_noerror_manytomanyfield.py
+++ b/pylint_django/tests/input/func_noerror_manytomanyfield.py
@@ -45,6 +45,15 @@ class CustomUser(AbstractUser):  # pylint: disable=model-no-explicit-unicode
             self.user_permissions.add(perm)
         return self.user_permissions
 
+    def add_permission(self, permission):
+        self.user_permissions.add(permission)
+
+    def remove_permission(self, permission):
+        self.user_permissions.remove(permission)
+
+    def set_permissions(self, permissions):
+        self.user_permissions.set(permissions)
+
     def save(self, *args, **kwargs):
         ''' Saving while granting new permissions '''
         self.is_staff = True


### PR DESCRIPTION
`remove` and `set` methods were missing on `RelatedManager`