### PR TITLE
Cherry-pick PR #234 with more documentation and passing tests

### DIFF
--- a/pylint_django/tests/input/models/func_noerror_foreign_key_key_cls_unbound_in_same_package.py
+++ b/pylint_django/tests/input/models/func_noerror_foreign_key_key_cls_unbound_in_same_package.py
@@ -1,0 +1,15 @@
+"""
+Checks that Pylint does not complain about ForeignKey pointing to model
+in module of models package
+"""
+# pylint: disable=missing-docstring
+from django.db import models
+
+
+class FairyTail(models.Model):
+    # fails with "UnboundLocalError: local variable 'key_cls' referenced before assignment"
+    # when 'Author' model comes from same models package
+    author = models.ForeignKey(to='Author', null=True, on_delete=models.CASCADE)
+
+    def get_author_name(self):
+        return self.author.id

--- a/pylint_django/tests/input/models/func_noerror_foreign_key_key_cls_unbound_in_same_package.py
+++ b/pylint_django/tests/input/models/func_noerror_foreign_key_key_cls_unbound_in_same_package.py
@@ -1,8 +1,16 @@
 """
-Checks that Pylint does not complain about ForeignKey pointing to model
-in module of models package
+Checks that Pylint does not crash with ForeignKey string reference pointing to model
+in module of models package. See
+https://github.com/PyCQA/pylint-django/issues/232
+
+Note: the no-member disable is here b/c pylint-django doesn't know how to
+load models.author.Author. When pylint-django tries to load models referenced
+by a single string it assumes they are found in the same module it is inspecting.
+Hence it can't find the Author class here so it tells us it doesn't have an
+'id' attribute. Also see:
+https://github.com/PyCQA/pylint-django/issues/232#issuecomment-495242695
 """
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring, no-member
 from django.db import models
 
 
@@ -12,4 +20,4 @@ class FairyTail(models.Model):
     author = models.ForeignKey(to='Author', null=True, on_delete=models.CASCADE)
 
     def get_author_name(self):
-        return self.author.id
+        return self.author.id  # disable via no-member

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -56,6 +56,7 @@ def get_tests(input_dir='input', sort=False):
 
 
 TESTS = get_tests()
+TESTS.extend(get_tests('input/models'))
 TESTS_NAMES = [t.base for t in TESTS]
 
 

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -44,7 +44,7 @@ def _get_model_class_defs_from_module(module, model_name, module_name):
 def infer_key_classes(node, context=None):
     keyword_args = []
     if node.keywords:
-        keyword_args = [kw.value for kw in node.keywords]
+        keyword_args = [kw.value for kw in node.keywords if kw.arg == 'to']
     all_args = chain(node.args, keyword_args)
 
     for arg in all_args:


### PR DESCRIPTION
@imomaliev I've cherry-picked your changes from #234 and added a pylint disable=no-member for the test to pass. The reason for that is b/c your patch only solves the traceback reported in #232 so the test will check only for that.

See also https://github.com/PyCQA/pylint-django/issues/232#issuecomment-495242695. The existing code base tries to be smart about which modules it loads before searching for model classes and not everything is loaded. I'm not even sure we can handle all cases or if we want to make the code even more complicated than it is.

The whole reason somebody needs to reference a FK model by string is circular dependencies in their own code which means they have to improve it in the first place. Which is something pylint is designed to help you with, not jumping through hoops so it is able to discover all of your files.

Once tests here pass I will merge and release a new version.