### PR TITLE
Fix too broad suppression of `unused-argument` warnings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@
 * [matusvalo](https://github.com/matusvalo)
 * [fadedDexofan](https://github.com/fadeddexofan)
 * [imomaliev](https://github.com/imomaliev)
+* [psrb](https://github.com/psrb)

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,10 @@ a test name, and insert into it some code. The tests will run pylint
 against these modules. If the idea is that no messages now occur, then
 that is fine, just check to see if it works by running ``scripts/test.sh``.
 
+Any command line argument passed to ``scripts/test.sh`` will be passed to the internal invocation of ``pytest``.
+For example if you want to debug the tests you can execute ``scripts/test.sh --capture=no``.
+A specific test case can be run by filtering based on the file name of the test case ``./scripts/test.sh -k 'func_noerror_views'``.
+
 Ideally, add some pylint error suppression messages to the file to prevent
 spurious warnings, since these are all tiny little modules not designed to
 do anything so there's no need to be perfect.

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ It is possible to make tests with expected error output, for example, if
 adding a new message or simply accepting that pylint is supposed to warn.
 A ``test_file_name.txt`` file contains a list of expected error messages in the
 format
-``error-type:line number:class name or empty:1st line of detailed error text``.
+``error-type:line number:class name or empty:1st line of detailed error text:confidence or empty``.
 
 
 License

--- a/pylint_django/tests/input/func_unused_arguments.py
+++ b/pylint_django/tests/input/func_unused_arguments.py
@@ -1,0 +1,40 @@
+"""
+Checks that Pylint still complains about unused-arguments for other
+arguments if a function/method contains an argument named `request`.
+"""
+# pylint: disable=missing-docstring
+
+from django.http import JsonResponse
+from django.views import View
+
+# Pylint generates the warning `redefined-outer-name` if an argument name shadows
+# a variable name from an outer scope. But if that argument name is ignored this
+# warning will not be generated.
+# Therefore define request here to cover this behaviour in this test case.
+
+request = None  # pylint: disable=invalid-name
+
+
+def user_detail(request, user_id):  # [unused-argument]
+    # nothing is done with user_id
+    return JsonResponse({'username': 'steve'})
+
+
+class UserView(View):
+    def get(self, request, user_id):  # [unused-argument]
+        # nothing is done with user_id
+        return JsonResponse({'username': 'steve'})
+
+
+# The following views are already covered in other test cases.
+# They are included here for completeness sake.
+
+def welcome_view(request):
+    # just don't use `request' b/c we could have Django views
+    # which never use it!
+    return JsonResponse({'message': 'welcome'})
+
+
+class CBV(View):
+    def get(self, request):
+        return JsonResponse({'message': 'hello world'})

--- a/pylint_django/tests/input/func_unused_arguments.txt
+++ b/pylint_django/tests/input/func_unused_arguments.txt
@@ -1,0 +1,2 @@
+unused-argument:18:user_detail:Unused argument 'user_id':HIGH
+unused-argument:24:UserView.get:Unused argument 'user_id':INFERENCE

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -29,6 +29,7 @@ class PylintDjangoLintModuleTest(test_functional.LintModuleTest):
     def __init__(self, test_file):
         super(PylintDjangoLintModuleTest, self).__init__(test_file)
         self._linter.load_plugin_modules(['pylint_django'])
+        self._linter.load_plugin_configuration()
 
 
 class PylintDjangoDbPerformanceTest(PylintDjangoLintModuleTest):
@@ -39,6 +40,7 @@ class PylintDjangoDbPerformanceTest(PylintDjangoLintModuleTest):
     def __init__(self, test_file):
         super(PylintDjangoDbPerformanceTest, self).__init__(test_file)
         self._linter.load_plugin_modules(['pylint_django.checkers.db_performance'])
+        self._linter.load_plugin_configuration()
 
 
 def get_tests(input_dir='input', sort=False):

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python pylint_django/tests/test_func.py -v
+python pylint_django/tests/test_func.py -v "$@"


### PR DESCRIPTION
This PR introduces the following changes:

#### Pass arguments provided to scripts/test.sh along to test_func/pytest
Previously you had to modify `scripts/test.sh` to pass new arguments to `pytest`. Now you can call `scripts/test.sh --capture=no` if you want to drop into the debugger when running tests 😃 

#### Ensure that load_configuration of pylint-django is called when running tests
Changes made in `load_configuration` can now be tested.

#### The main part of this PR is the bugfix for  #249

As described in #249 the suppression of the `unused-argument` warning if a function contains an argument named `request` was too broad. 

##### Implementation
- I have reverted most of the changes made in https://github.com/PyCQA/pylint-django/commit/e4c8fc70af33b227371c6e0e80b0dccf0ad157fa and
- pylint-django now extends Pylints `ignored-argument-names` regex to included `request`. This way other `unused-argument` warnings will still be issued!
- I have added two test cases verify this behaviour
   - I documented how to define the expected confidence level in the txt files. The confidence level for UserView.get was `INTERFERENCE` and not the default value of `HIGH`.

#### Note on failing tests
I have tested my changes locally using Pylint 2.3.1. The CI pipeline currently fails because of changes made in the Pylint repository (see #250 for more information).
