### PR TITLE
Do not rely on the version number to know if the tests are present and fixing test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ matrix:
     - { stage: test, python: 3.6, env: TOXENV=readme }
     - { stage: build_and_package_sanity, python: 3.6, env: SANITY_CHECK=1 }
 
-before_install:
-  - git clone --depth 1 https://github.com/PyCQA/pylint.git ~/pylint
-
 install:
   - pip install tox-travis
   - pip install -e .[for_tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 
 install:
   - pip install tox-travis
-  - pip install -e .[for_tests]
 script:
   - |
         if [ -z "$SANITY_CHECK" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     - { stage: test, python: 3.6, env: TOXENV=readme }
     - { stage: build_and_package_sanity, python: 3.6, env: SANITY_CHECK=1 }
 
+before_install:
+  - git clone --depth 1 https://github.com/PyCQA/pylint.git --branch 2.4 --single-branch ~/pylint
 install:
   - pip install tox-travis
   - pip install -e .[for_tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,11 @@ matrix:
     - { stage: test, python: 3.6, env: TOXENV=readme }
     - { stage: build_and_package_sanity, python: 3.6, env: SANITY_CHECK=1 }
 
+# This is a hack to go around missing test_functional in pip packages for pylint 2.4 and should be removed when relying
+# on pylint >2.5 (along with a cleanup of pylint_django/tests/test_func.py)
 before_install:
   - git clone --depth 1 https://github.com/PyCQA/pylint.git --branch 2.4 --single-branch ~/pylint
+
 install:
   - pip install tox-travis
   - pip install -e .[for_tests]

--- a/pylint_django/tests/input/func_noerror_foreign_key_package.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_package.py
@@ -7,7 +7,7 @@ from django.db import models
 
 
 class Book(models.Model):
-    author = models.ForeignKey(to='input.Author', on_delete=models.CASCADE)
+    author = models.ForeignKey(to='pylint_django.tests.input.Author', on_delete=models.CASCADE)
 
     def get_author_name(self):
         return self.author.id

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -6,6 +6,7 @@ import pytest
 import pylint
 
 # PYLINT_TEST_FUNCTIONAL_PATH is can be used to force where to pull the classes used for functional testing
+# Just make sure you use the exact same version as the one pylint version installed or just add that to PYTHONPATH
 pylint_test_func_path = os.getenv('PYLINT_TEST_FUNCTIONAL_PATH', '')
 if pylint_test_func_path != '':
     sys.path.append(pylint_test_func_path)
@@ -19,15 +20,15 @@ except (ImportError, AttributeError):
     try:
         from pylint.testutils import FunctionalTestFile, LintModuleTest
     except (ImportError, AttributeError):
+        # test in other more exotic directories
         if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
-            # because there's no __init__ file in pylint/test
+            # pre pylint 2.4, pylint was putting files in pylint/test
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
-        else:
-            # after version 2.4 pylint stopped shipping the test directory
-            # as part of the package so we check it out locally for testing
+        elif os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), '..', 'tests')):
+            # after version 2.4 pylint moved the test to a 'tests' folder at the root of the github tree
+            # to stopped shipping the tests along with the pip package
             # but some distro re-add tests in the packages so only do that when not done at all
-            # Just make sure you use the exact same version as the one installed for the test files!!!
-            sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
+            sys.path.append(os.path.join(os.path.dirname(pylint.__file__), '..', 'tests'))
         try:
             from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
         except (ImportError, AttributeError):

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -5,6 +5,8 @@ import pytest
 
 import pylint
 
+print('DEBUG: pylint version: {}'.format(pylint.__version__))
+
 # PYLINT_TEST_FUNCTIONAL_PATH is can be used to force where to pull the classes used for functional testing
 # Just make sure you use the exact same version as the one pylint version installed or just add that to PYTHONPATH
 pylint_test_func_path = os.getenv('PYLINT_TEST_FUNCTIONAL_PATH', '')
@@ -15,26 +17,31 @@ if pylint_test_func_path != '':
 # so we try first to load the basic cases and then look in more exotic places
 try:
     # pylint <= 2.4 case
+    # TODO: remove when the minimum supported version of pylint is 2.5.
     from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
 except (ImportError, AttributeError):
     try:
         from pylint.testutils import FunctionalTestFile, LintModuleTest
     except (ImportError, AttributeError):
-        print("DEBUG: This should not appear on pylint 2.5")
         # test in other more exotic directories
         if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
             # pre pylint 2.4, pylint was putting files in pylint/test
+            # TODO: remove when the minimum supported version of pylint is 2.4.
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
         elif os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), '..', 'tests')):
             # after version 2.4 pylint moved the test to a 'tests' folder at the root of the github tree
             # to stopped shipping the tests along with the pip package
             # but some distro re-add tests in the packages so only do that when not done at all
+            # TODO: remove when the minimum supported version of pylint is 2.5.
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), '..', 'tests'))
         else:
-            print("DEBUG: we should not enter this condition with pylint 2.5")
             # This is a transitional hack specific to pylint 2.4 on travis and should be irrelevant anywhere else
+            # TODO: remove when the minimum supported version of pylint is 2.5.
             sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
         try:
+            print("DEBUG: we should not enter this condition with pylint 2.5")
+            # TODO: remove when the minimum supported version of pylint is 2.5.
+            sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
             from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
         except (ImportError, AttributeError):
             from pylint.testutils import FunctionalTestFile, LintModuleTest

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -29,6 +29,9 @@ except (ImportError, AttributeError):
             # to stopped shipping the tests along with the pip package
             # but some distro re-add tests in the packages so only do that when not done at all
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), '..', 'tests'))
+        else:
+            # This is a transitional hack specific to pylint 2.4 on travis and should be irrelevant anywhere else
+            sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
         try:
             from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
         except (ImportError, AttributeError):

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -5,7 +5,7 @@ import pytest
 
 import pylint
 
-# If PYLINT_TEST_FUNCTIONAL_PATH is set it should be used to specify where to pull the test_functional method from.
+# PYLINT_TEST_FUNCTIONAL_PATH is can be used to force where to pull the classes used for functional testing
 pylint_test_func_path = os.getenv('PYLINT_TEST_FUNCTIONAL_PATH', '')
 if pylint_test_func_path == '':
     if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
@@ -22,7 +22,7 @@ sys.path.append(pylint_test_func_path)
 try:
     # pylint <= 2.4 case
     from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
-except ImportError:
+except AttributeError:
     from pylint.testutils import FunctionalTestFile, LintModuleTest
 
 # alter sys.path again because the tests now live as a subdirectory

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -5,14 +5,18 @@ import pytest
 
 import pylint
 
-if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
-    # because there's no __init__ file in pylint/test
-    sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
-else:
-    # after version 2.4 pylint stopped shipping the test directory
-    # as part of the package so we check it out locally for testing
-    # but some distro re-add tests in the packages so only do that when not done at all
-    sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
+# If PYLINT_TESTS_PATH is set it should be used to specify where to pull the tests from
+pylint_tests_path = os.getenv('PYLINT_TESTS_PATH', '')
+if pylint_tests_path == '':
+    if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
+        # because there's no __init__ file in pylint/test
+        pylint_tests_path = os.path.join(os.path.dirname(pylint.__file__), 'test')
+    else:
+        # after version 2.4 pylint stopped shipping the test directory
+        # as part of the package so we check it out locally for testing
+        # but some distro re-add tests in the packages so only do that when not done at all
+        pylint_tests_path = os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests')
+sys.path.append(pylint_tests_path)
 
 import test_functional  # noqa: E402
 

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -15,7 +15,7 @@ if pylint_test_func_path != '':
 try:
     # pylint <= 2.4 case
     from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
-except (ModuleNotFoundError, AttributeError):
+except (ImportError, AttributeError):
     try:
         from pylint.testutils import FunctionalTestFile, LintModuleTest
     except (ImportError, AttributeError):
@@ -30,7 +30,7 @@ except (ModuleNotFoundError, AttributeError):
             sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
         try:
             from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
-        except (ModuleNotFoundError, AttributeError):
+        except (ImportError, AttributeError):
             from pylint.testutils import FunctionalTestFile, LintModuleTest
 
 # alter sys.path again because the tests now live as a subdirectory

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -15,10 +15,10 @@ if pylint_test_func_path != '':
 try:
     # pylint <= 2.4 case
     from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
-except AttributeError:
+except (ModuleNotFoundError, AttributeError):
     try:
         from pylint.testutils import FunctionalTestFile, LintModuleTest
-    except AttributeError:
+    except (ImportError, AttributeError):
         if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
             # because there's no __init__ file in pylint/test
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
@@ -26,10 +26,11 @@ except AttributeError:
             # after version 2.4 pylint stopped shipping the test directory
             # as part of the package so we check it out locally for testing
             # but some distro re-add tests in the packages so only do that when not done at all
+            # Just make sure you use the exact same version as the one installed for the test files!!!
             sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
         try:
             from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
-        except AttributeError:
+        except (ModuleNotFoundError, AttributeError):
             from pylint.testutils import FunctionalTestFile, LintModuleTest
 
 # alter sys.path again because the tests now live as a subdirectory

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -5,20 +5,25 @@ import pytest
 
 import pylint
 
-# If PYLINT_TESTS_PATH is set it should be used to specify where to pull the tests from
-pylint_tests_path = os.getenv('PYLINT_TESTS_PATH', '')
-if pylint_tests_path == '':
+# If PYLINT_TEST_FUNCTIONAL_PATH is set it should be used to specify where to pull the test_functional method from.
+pylint_test_func_path = os.getenv('PYLINT_TEST_FUNCTIONAL_PATH', '')
+if pylint_test_func_path == '':
     if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
         # because there's no __init__ file in pylint/test
-        pylint_tests_path = os.path.join(os.path.dirname(pylint.__file__), 'test')
+        pylint_test_func_path = os.path.join(os.path.dirname(pylint.__file__), 'test')
     else:
         # after version 2.4 pylint stopped shipping the test directory
         # as part of the package so we check it out locally for testing
         # but some distro re-add tests in the packages so only do that when not done at all
-        pylint_tests_path = os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests')
+        pylint_test_func_path = os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests')
 sys.path.append(pylint_tests_path)
 
-import test_functional  # noqa: E402
+# test_functional has been moved to pylint.testutils as part of the pytlint 2.5 release
+try:
+    import pylint.testutils as test_functional
+except ImportError:
+    # pylint <= 2.4 case
+    import test_functional  # noqa: E402
 
 # alter sys.path again because the tests now live as a subdirectory
 # of pylint_django

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -21,9 +21,9 @@ sys.path.append(pylint_test_func_path)
 # test_functional has been moved to pylint.testutils as part of the pytlint 2.5 release
 try:
     # pylint <= 2.4 case
-    import test_functional  # noqa: E402
+    from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402
 except ImportError:
-    from pylint import testutils as test_functional
+    from pylint.testutils import FunctionalTestFile, LintModuleTest
 
 # alter sys.path again because the tests now live as a subdirectory
 # of pylint_django
@@ -32,7 +32,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 sys.path.append(os.path.join(os.path.dirname(__file__), 'input'))
 
 
-class PylintDjangoLintModuleTest(test_functional.LintModuleTest):
+class PylintDjangoLintModuleTest(LintModuleTest):
     """
         Only used so that we can load this plugin into the linter!
     """
@@ -63,7 +63,7 @@ def get_tests(input_dir='input', sort=False):
     suite = []
     for fname in os.listdir(input_dir):
         if fname != '__init__.py' and fname.endswith('.py'):
-            suite.append(test_functional.FunctionalTestFile(input_dir, fname))
+            suite.append(FunctionalTestFile(input_dir, fname))
 
     # when testing the db_performance plugin we need to sort by input file name
     # because the plugin reports the errors in close() which appends them to the

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -20,10 +20,10 @@ sys.path.append(pylint_test_func_path)
 
 # test_functional has been moved to pylint.testutils as part of the pytlint 2.5 release
 try:
-    from pylint import testutils as test_functional
-except ImportError:
     # pylint <= 2.4 case
     import test_functional  # noqa: E402
+except ImportError:
+    from pylint import testutils as test_functional
 
 # alter sys.path again because the tests now live as a subdirectory
 # of pylint_django

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -5,8 +5,6 @@ import pytest
 
 import pylint
 
-print('DEBUG: pylint version: {}'.format(pylint.__version__))
-
 # PYLINT_TEST_FUNCTIONAL_PATH is can be used to force where to pull the classes used for functional testing
 # Just make sure you use the exact same version as the one pylint version installed or just add that to PYTHONPATH
 pylint_test_func_path = os.getenv('PYLINT_TEST_FUNCTIONAL_PATH', '')
@@ -39,7 +37,6 @@ except (ImportError, AttributeError):
             # TODO: remove when the minimum supported version of pylint is 2.5.
             sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
         try:
-            print("DEBUG: we should not enter this condition with pylint 2.5")
             # TODO: remove when the minimum supported version of pylint is 2.5.
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
             from test_functional import FunctionalTestFile, LintModuleTest  # noqa: E402

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -5,13 +5,14 @@ import pytest
 
 import pylint
 
-if pylint.__version__ >= '2.4':
+if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
+    # because there's no __init__ file in pylint/test
+    sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
+else:
     # after version 2.4 pylint stopped shipping the test directory
     # as part of the package so we check it out locally for testing
+    # but some distro re-add tests in the packages so only do that when not done at all
     sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
-else:
-    # because there's no __init__ file in pylint/test/
-    sys.path.append(os.path.join(os.path.dirname(pylint.__file__), 'test'))
 
 import test_functional  # noqa: E402
 

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -20,6 +20,7 @@ except (ImportError, AttributeError):
     try:
         from pylint.testutils import FunctionalTestFile, LintModuleTest
     except (ImportError, AttributeError):
+        print("DEBUG: This should not appear on pylint 2.5")
         # test in other more exotic directories
         if os.path.isdir(os.path.join(os.path.dirname(pylint.__file__), 'test')):
             # pre pylint 2.4, pylint was putting files in pylint/test
@@ -30,6 +31,7 @@ except (ImportError, AttributeError):
             # but some distro re-add tests in the packages so only do that when not done at all
             sys.path.append(os.path.join(os.path.dirname(pylint.__file__), '..', 'tests'))
         else:
+            print("DEBUG: we should not enter this condition with pylint 2.5")
             # This is a transitional hack specific to pylint 2.4 on travis and should be irrelevant anywhere else
             sys.path.append(os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests'))
         try:

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -16,11 +16,11 @@ if pylint_test_func_path == '':
         # as part of the package so we check it out locally for testing
         # but some distro re-add tests in the packages so only do that when not done at all
         pylint_test_func_path = os.path.join(os.getenv('HOME', '/home/travis'), 'pylint', 'tests')
-sys.path.append(pylint_tests_path)
+sys.path.append(pylint_test_func_path)
 
 # test_functional has been moved to pylint.testutils as part of the pytlint 2.5 release
 try:
-    import pylint.testutils as test_functional
+    from pylint import testutils as test_functional
 except ImportError:
     # pylint <= 2.4 case
     import test_functional  # noqa: E402

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 
 [testenv]
 commands =
-    django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py\'
+    django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
     django_is_installed: pylint --load-plugins=pylint_django setup.py
     flake8: flake8
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
@@ -25,7 +25,6 @@ commands =
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
 deps =
     coverage
-    django_tables2
     factory-boy
     pytest
     django_is_installed: Django
@@ -33,16 +32,19 @@ deps =
     django_is_installed: pylint
     flake8: flake8
     pylint: pylint
-    pylint: Django
     pylint: pylint-plugin-utils
+    pylint: Django
+    pylint: django_tables2
     readme: twine
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
-    django{111,20,21,22}: pylint-plugin-utils
     django{111,20,21,22}: pylint
+    django{111,20,21,22}: pylint-plugin-utils
+    django{111,20,21,22}: django_tables2
     django-master: Django
+    django-master: django_tables2
     django-master: git+https://github.com/pycqa/astroid@master
     django-master: git+https://github.com/pycqa/pylint@master
     django-master: git+https://github.com/PyCQA/pylint-plugin-utils@master

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,9 @@ commands =
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
 deps =
     coverage
+    django_tables2
+    factory-boy
+    pytest
     django_is_installed: Django
     flake8: flake8
     pylint: pylint

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     django_not_installed
     django_is_installed
     flake8
-    pylint
+    pylintpkg
     readme
     py{36}-django{111,20,-master}
     py{35,36,37}-django22
@@ -16,7 +16,7 @@ commands =
     django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
     django_is_installed: pylint --load-plugins=pylint_django setup.py
     flake8: flake8
-    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
+    pylintpkg: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django22: coverage run pylint_django/tests/test_func.py -v
@@ -26,8 +26,8 @@ commands =
 deps =
     django_is_installed: Django
     flake8: flake8
-    pylint: pylint
-    pylint: Django
+    pylintpkg: pylint
+    pylintpkg: Django
     readme: twine
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 
 [testenv]
 commands =
-    django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
+    django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py\'
     django_is_installed: pylint --load-plugins=pylint_django setup.py
     flake8: flake8
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     django_not_installed
     django_is_installed
     flake8
-    pylintpkg
+    pylint
     readme
     py{36}-django{111,20,-master}
     py{35,36,37}-django22
@@ -16,7 +16,7 @@ commands =
     django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
     django_is_installed: pylint --load-plugins=pylint_django setup.py
     flake8: flake8
-    pylintpkg: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
+    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django22: coverage run pylint_django/tests/test_func.py -v
@@ -24,10 +24,11 @@ commands =
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
 deps =
+    coverage
     django_is_installed: Django
     flake8: flake8
-    pylintpkg: pylint
-    pylintpkg: Django
+    pylint: pylint
+    pylint: Django
     readme: twine
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     factory-boy
     pytest
     django_is_installed: Django
+    django_is_installed: pylint-plugin-utils
     django_is_installed: pylint
     flake8: flake8
     pylint: pylint

--- a/tox.ini
+++ b/tox.ini
@@ -29,17 +29,22 @@ deps =
     factory-boy
     pytest
     django_is_installed: Django
+    django_is_installed: pylint
     flake8: flake8
     pylint: pylint
     pylint: Django
+    pylint: pylint-plugin-utils
     readme: twine
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
+    django{111,20,21,22}: pylint-plugin-utils
+    django{111,20,21,22}: pylint
     django-master: Django
     django-master: git+https://github.com/pycqa/astroid@master
     django-master: git+https://github.com/pycqa/pylint@master
+    django-master: git+https://github.com/PyCQA/pylint-plugin-utils@master
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
     PYTHONPATH = .


### PR DESCRIPTION
Hi guys,

Sometimes the distro re-add the files that were removed from the pip packages and in this case it will probably be the case in a few days, so maybe it would be better to check if the test directory exists instead of relying on the version. What do you think?

Thanks for your help,
Joseph