### PR TITLE
Another take on PR #256 so we can have tests working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - { stage: build_and_package_sanity, python: 3.6, env: SANITY_CHECK=1 }
 
 before_install:
-  - git clone --depth 1 https://github.com/PyCQA/pylint.git ~/pylint
+  - git clone --depth 1 https://github.com/PyCQA/pylint.git --branch 2.4 --single-branch ~/pylint
 
 install:
   - pip install tox-travis

--- a/pylint_django/tests/input/func_noerror_foreign_key_package.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_package.py
@@ -7,7 +7,7 @@ from django.db import models
 
 
 class Book(models.Model):
-    author = models.ForeignKey(to='input.Author', on_delete=models.CASCADE)
+    author = models.ForeignKey(to='pylint_django.tests.input.Author', on_delete=models.CASCADE)
 
     def get_author_name(self):
         return self.author.id


### PR DESCRIPTION
@aerostitch I've taken your changes from #256 and squashed related commits together and removed some things and updated the order of operations. 

- try to import test classes from `pylint.testutils` - will work once we have 2.5 released
- for Travis CI just git clone the 2.4 branch from which we can import `tests_functional`. The code will try to use `PYLINT_TEST_FUNCTIONAL_DIR` but will default to the Travis location
- if that fails try to use an older location

The only reason you may need these changes is if you are trying to either develop/test pylint-django locally or maybe you are trying to build a binary package for a Linux distro. The changes above should make it possible to workaround the current state of affairs.

Or alternatively install pylint from master branch and use that instead.


Tell me what you think ? 