### PR TITLE
Update codebase for Django 3 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - 3.7-dev
   - 3.8
 env:
   # note: latest versions first b/c the top-most is included in new

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ python:
   - 3.6
   - 3.7
   - 3.7-dev
+  - 3.8
 env:
   # note: latest versions first b/c the top-most is included in new
   # build stages if not specified
+  - DJANGO=3.0
   - DJANGO=2.2
 stages:
   - django_not_installed
@@ -18,6 +20,7 @@ matrix:
   include:
     - { stage: django_not_installed, python: 3.6, env: TOXENV=django_not_installed }
     - { stage: django_is_installed, python: 3.6, env: TOXENV=django_is_installed }
+    - { stage: test, python: 3.6, env: DJANGO=3.0 }
     - { stage: test, python: 3.6, env: DJANGO=2.0 }
     - { stage: test, python: 3.6, env: DJANGO=1.11 }
     - { stage: test, python: 3.6, env: DJANGO=master }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.0.14 (09 Feb 2020)
+--------------------------------------------------
+
+- Add support for Django 3.0 and Python 3.8
+
+
 Version 2.0.13 (23 Nov 2019), HackBulgaria edition
 --------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Version 2.0.14 (09 Feb 2020)
+Version 2.0.14
 --------------------------------------------------
 
 - Add support for Django 3.0 and Python 3.8

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@
 * [fadedDexofan](https://github.com/fadeddexofan)
 * [imomaliev](https://github.com/imomaliev)
 * [psrb](https://github.com/psrb)
+* [WayneLambert](https://github.com/WayneLambert)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email='code@landscape.io',
     description='A Pylint plugin to help Pylint understand the Django web framework',
     long_description=LONG_DESCRIPTION,
-    version='2.0.13',
+    version='2.0.14',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
@@ -34,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords=['pylint', 'django', 'plugin'],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     readme
     py{36}-django{111,20,-master}
     py{35,36,37}-django22
+    py{36,37,38}-django30
 
 [testenv]
 commands =
@@ -20,6 +21,7 @@ commands =
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django22: coverage run pylint_django/tests/test_func.py -v
+    py{36,37,38}-django30: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
@@ -33,6 +35,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
     django-master: Django
     django-master: git+https://github.com/pycqa/astroid@master
     django-master: git+https://github.com/pycqa/pylint@master
@@ -44,6 +47,7 @@ whitelist_externals =
     readme: bash
     py{36}-django{111,20,-master}: coverage
     py{35,36,37}-django22: coverage
+    py{36,37,38}-django30: coverage
     clean: find
     clean: rm
 
@@ -53,6 +57,7 @@ DJANGO =
     2.0: django20
     2.1: django21
     2.2: django22
+    3.0: django30
     master: django-master
 
 [flake8]


### PR DESCRIPTION
Upgrades to `tox.ini`, `travis.yml` and `setup.py` to run tests against Python 3.8 and Django 3.0

Also, the version number has been bumped in `CHANGELOG.rst` and my name added in `CONTRIBUTORS.md`