### PR TITLE
Path removed django.utils.encoding.python_2_unicode_compatible()

### DIFF
--- a/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.py
+++ b/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.py
@@ -6,7 +6,7 @@ having explicitly defined __unicode__
 #  pylint: disable=missing-docstring
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
+++ b/pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
@@ -5,7 +5,7 @@ Django python3/2 compatability dectorator is used
 See https://github.com/PyCQA/pylint-django/issues/10
 """
 #  pylint: disable=missing-docstring
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.db import models
 
 


### PR DESCRIPTION
- causes no-name-in-module errors.
- has been removed in Django 3.0
- is alias of six.python_2_unicode_compatible()

https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis