### PR TITLE
Fix error for gettext_lazy

### DIFF
--- a/pylint_django/tests/input/func_noerror_gettext_lazy_format.py
+++ b/pylint_django/tests/input/func_noerror_gettext_lazy_format.py
@@ -1,0 +1,7 @@
+"""
+Checks that Pylint does not complain about django lazy proxy
+when using gettext_lazy
+"""
+from django.utils.translation import gettext_lazy
+
+gettext_lazy('{something}').format(something='lala')

--- a/pylint_django/transforms/transforms/django_utils_translation.py
+++ b/pylint_django/transforms/transforms/django_utils_translation.py
@@ -1,2 +1,5 @@
-def ugettext_lazy(_):
+def gettext_lazy(_):
     return ''
+
+
+ugettext_lazy = gettext_lazy  # pylint:disable=invalid-name


### PR DESCRIPTION
Hey :)

ugettext_lazy will soon be removed in favour of gettext_lazy. See https://docs.djangoproject.com/en/3.0/releases/3.0/#id3 for more details.

This fix a very similar issue to https://github.com/PyCQA/pylint-django/issues/80. We (with @rik) also added a test.