### PR TITLE
Add missing CSV dialect for tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,5 @@
 * [imomaliev](https://github.com/imomaliev)
 * [psrb](https://github.com/psrb)
 * [WayneLambert](https://github.com/WayneLambert)
+* [alejandro-angulo](https://github.com/alejandro-angulo)
+

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -15,7 +15,6 @@ try:
             delimiter = ":"
             lineterminator = "\n"
 
-
         csv.register_dialect("test", test_dialect)
 except (ImportError, AttributeError):
     # specify directly the directory containing test_functional.py

--- a/pylint_django/tests/test_func.py
+++ b/pylint_django/tests/test_func.py
@@ -1,4 +1,4 @@
-
+import csv
 import os
 import sys
 import pytest
@@ -9,6 +9,14 @@ import pylint
 try:
     # pylint 2.5: test_functional has been moved to pylint.testutils
     from pylint.testutils import FunctionalTestFile, LintModuleTest
+
+    if "test" not in csv.list_dialects():
+        class test_dialect(csv.excel):
+            delimiter = ":"
+            lineterminator = "\n"
+
+
+        csv.register_dialect("test", test_dialect)
 except (ImportError, AttributeError):
     # specify directly the directory containing test_functional.py
     test_functional_dir = os.getenv('PYLINT_TEST_FUNCTIONAL_DIR', '')


### PR DESCRIPTION
Address #268 (unknown CSV dialect) by registering the same CSV dialect as pylint does in their tests: https://github.com/PyCQA/pylint/blob/369d952c7e5df010932cf89e528b2f6e9ff08dd6/tests/test_functional.py#L33-L38 .