### PR TITLE
New linter: warn about missing backwards migrations

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,4 +15,5 @@
 * [psrb](https://github.com/psrb)
 * [WayneLambert](https://github.com/WayneLambert)
 * [alejandro-angulo](https://github.com/alejandro-angulo)
+* [brymut](https://github.com/brymut)
 

--- a/pylint_django/tests/input/migrations/0003_without_backwards.py
+++ b/pylint_django/tests/input/migrations/0003_without_backwards.py
@@ -1,0 +1,20 @@
+# pylint: disable=missing-docstring, invalid-name
+from django.db import migrations
+
+
+# pylint: disable=unused-argument
+def forwards_test(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    operations = [
+        migrations.RunPython(),  # [missing-backwards-migration-callable]
+        migrations.RunPython(  # [missing-backwards-migration-callable]
+            forwards_test),
+        migrations.RunPython(  # [missing-backwards-migration-callable]
+            code=forwards_test),
+        migrations.RunPython(  # [missing-backwards-migration-callable]
+            code=forwards_test, atomic=False)
+    ]

--- a/pylint_django/tests/input/migrations/0003_without_backwards.txt
+++ b/pylint_django/tests/input/migrations/0003_without_backwards.txt
@@ -1,0 +1,4 @@
+missing-backwards-migration-callable:13:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
+missing-backwards-migration-callable:14:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
+missing-backwards-migration-callable:16:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
+missing-backwards-migration-callable:18:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable

--- a/pylint_django/tests/input/migrations/0004_noerror_with_backwards.py
+++ b/pylint_django/tests/input/migrations/0004_noerror_with_backwards.py
@@ -1,0 +1,21 @@
+# pylint: disable=missing-docstring, invalid-name
+from django.db import migrations
+
+
+# pylint: disable=unused-argument
+def forwards_test(apps, schema_editor):
+    pass
+
+
+# pylint: disable=unused-argument
+def backwards_test(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    operations = [
+        migrations.RunPython(forwards_test, backwards_test),
+        migrations.RunPython(forwards_test, reverse_code=backwards_test),
+        migrations.RunPython(code=forwards_test, reverse_code=backwards_test)
+    ]

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -1,5 +1,6 @@
 """Utils."""
 import sys
+import astroid
 
 from astroid.bases import Instance
 from astroid.exceptions import InferenceError
@@ -30,3 +31,10 @@ def node_is_subclass(cls, *subclass_names):
             continue
 
     return False
+
+
+def is_migrations_module(node):
+    if not isinstance(node, astroid.Module):
+        return False
+
+    return 'migrations' in node.path[0] and not node.path[0].endswith('__init__.py')


### PR DESCRIPTION
Refs kiwitcms/Kiwi#1774 New linter: warn about missing backwards migrations.

@atodorov, not quite sure how to handle/structure the testing for this. Should I add migrations to test with on top of the tests for the db_performance checker or should I have it with the other checkers? As it looks like the db_performance is added on separately to add the migrations path?