### PR TITLE
Suppress unused-argument for functions in migration modules

### DIFF
--- a/pylint_django/tests/input/migrations/0003_without_backwards.py
+++ b/pylint_django/tests/input/migrations/0003_without_backwards.py
@@ -2,7 +2,6 @@
 from django.db import migrations
 
 
-# pylint: disable=unused-argument
 def forwards_test(apps, schema_editor):
     pass
 

--- a/pylint_django/tests/input/migrations/0003_without_backwards.txt
+++ b/pylint_django/tests/input/migrations/0003_without_backwards.txt
@@ -1,4 +1,4 @@
+missing-backwards-migration-callable:12:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
 missing-backwards-migration-callable:13:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
-missing-backwards-migration-callable:14:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
-missing-backwards-migration-callable:16:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
-missing-backwards-migration-callable:18:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
+missing-backwards-migration-callable:15:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
+missing-backwards-migration-callable:17:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable

--- a/pylint_django/tests/input/migrations/0004_noerror_with_backwards.py
+++ b/pylint_django/tests/input/migrations/0004_noerror_with_backwards.py
@@ -2,12 +2,10 @@
 from django.db import migrations
 
 
-# pylint: disable=unused-argument
 def forwards_test(apps, schema_editor):
     pass
 
 
-# pylint: disable=unused-argument
 def backwards_test(apps, schema_editor):
     pass
 


### PR DESCRIPTION
usually these are functions used in migrations.RunPython() but
the suppression code is not that smart and will suppress any
unused-argument which is triggered by functions defined inside a
migrations module.

@carlio I've started using the new pylint_django.checkers.migrations in my own projects and started hitting this. What do you think ? 