### PR TITLE
Fix (missing-backwards-migration-callable) error message

### DIFF
--- a/pylint_django/checkers/migrations.py
+++ b/pylint_django/checkers/migrations.py
@@ -117,7 +117,7 @@ class MissingBackwardsMigrationChecker(checkers.BaseChecker):
 
     name = 'missing-backwards-migration-callable'
 
-    msgs = {'W%s97' % BASE_ID: ('%s Always include backwards migration callable',
+    msgs = {'W%s97' % BASE_ID: ('Always include backwards migration callable',
                                 'missing-backwards-migration-callable',
                                 'Always include a backwards/reverse callable counterpart'
                                 ' so that the migration is not irreversable.')}
@@ -138,10 +138,10 @@ class MissingBackwardsMigrationChecker(checkers.BaseChecker):
                     if keyword.arg == 'reverse_code':
                         return
                 self.add_message('missing-backwards-migration-callable',
-                                 args=module.name, node=node)
+                                 node=node)
             else:
                 self.add_message('missing-backwards-migration-callable',
-                                 args=module.name, node=node)
+                                 node=node)
 
 
 def is_in_migrations(node):

--- a/pylint_django/tests/input/migrations/0003_without_backwards.txt
+++ b/pylint_django/tests/input/migrations/0003_without_backwards.txt
@@ -1,4 +1,4 @@
-missing-backwards-migration-callable:12:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
-missing-backwards-migration-callable:13:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
-missing-backwards-migration-callable:15:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
-missing-backwards-migration-callable:17:Migration:pylint_django.tests.input.migrations.0003_without_backwards Always include backwards migration callable
+missing-backwards-migration-callable:12:Migration:Always include backwards migration callable
+missing-backwards-migration-callable:13:Migration:Always include backwards migration callable
+missing-backwards-migration-callable:15:Migration:Always include backwards migration callable
+missing-backwards-migration-callable:17:Migration:Always include backwards migration callable


### PR DESCRIPTION
Fix (missing-backwards-migration-callable) error message problem with file name repetition. @atodorov 