### PR TITLE
Better error message when Django is not configured. Closes #277

### DIFF
--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -53,6 +53,8 @@ def _module_name_from_django_model_resolution(model_name, module_name):
 
 
 def infer_key_classes(node, context=None):
+    from django.core.exceptions import ImproperlyConfigured  # pylint: disable=import-outside-toplevel
+
     keyword_args = []
     if node.keywords:
         keyword_args = [kw.value for kw in node.keywords if kw.arg == 'to']
@@ -106,6 +108,9 @@ def infer_key_classes(node, context=None):
                     # 'auth.models', 'User' which works nicely with the `endswith()`
                     # comparison below
                     module_name += '.models'
+                except ImproperlyConfigured:
+                    raise RuntimeError("DJANGO_SETTINGS_MODULE required for resolving ForeignKey "
+                                       "string references, see Usage section in README!")
 
                 # ensure that module is loaded in astroid_cache, for cases when models is a package
                 if module_name not in MANAGER.astroid_cache:


### PR DESCRIPTION
if Django isn't configured, that is DJANGO_SETTINGS_MODULE isn't
available in the environment, then raise a RuntimeError with message

DJANGO_SETTINGS_MODULE required for resolving ForeignKey string
references, see Usage section in README!

My command line example is below.  

```
$ PYTHONPATH=. pylint --load-plugins pylint_django pylint_django/tests/input/func_noerror_foreign*
Traceback (most recent call last):
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/astroid/__init__.py", line 93, in _inference_tip_cached
    return iter(_cache[func, node])
KeyError: (<function infer_key_classes at 0x7faddc7047b8>, <Call l.11 at 0x7faddafec3c8>)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/senko/pylint-django/pylint_django/transforms/foreignkey.py", line 104, in infer_key_classes
    module_name = _module_name_from_django_model_resolution(model_name, module_name)
  File "/home/senko/pylint-django/pylint_django/transforms/foreignkey.py", line 47, in _module_name_from_django_model_resolution
    django.setup()
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/django/__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/django/conf/__init__.py", line 76, in __getattr__
    self._setup(name)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/django/conf/__init__.py", line 61, in _setup
    % (desc, ENVIRONMENT_VARIABLE))
django.core.exceptions.ImproperlyConfigured: Requested setting LOGGING_CONFIG, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/senko/.virtualenvs/pylint-django/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/__init__.py", line 22, in run_pylint
    PylintRun(sys.argv[1:])
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/lint/run.py", line 344, in __init__
    linter.check(args)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 871, in check
    self.get_ast, self._iterate_file_descrs(files_or_modules)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 904, in _check_files
    self._check_file(get_ast, check_astroid_module, name, filepath, modname)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 930, in _check_file
    check_astroid_module(ast_node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 1063, in check_astroid_module
    ast_node, walker, rawcheckers, tokencheckers
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/lint/pylinter.py", line 1107, in _check_astroid_module
    walker.walk(ast_node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 55, in augment_func
    augmentation(chain, node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 146, in do_suppress
    chain()
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 54, in chain
    old_method(node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 55, in augment_func
    augmentation(chain, node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 146, in do_suppress
    chain()
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 54, in chain
    old_method(node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 55, in augment_func
    augmentation(chain, node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 146, in do_suppress
    chain()
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 54, in chain
    old_method(node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 55, in augment_func
    augmentation(chain, node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 146, in do_suppress
    chain()
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint_plugin_utils/__init__.py", line 54, in chain
    old_method(node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/checkers/classes.py", line 788, in visit_classdef
    self._check_bases_classes(node)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/checkers/classes.py", line 1608, in _check_bases_classes
    unimplemented_abstract_methods(node, is_abstract).items(),
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/checkers/utils.py", line 819, in unimplemented_abstract_methods
    inferred = safe_infer(obj)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/pylint/checkers/utils.py", line 1119, in safe_infer
    value = next(infer_gen)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/astroid/decorators.py", line 132, in raise_if_nothing_inferred
    yield next(generator)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/astroid/decorators.py", line 96, in wrapped
    res = next(generator)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/astroid/bases.py", line 136, in _infer_stmts
    for inferred in stmt.infer(context=context):
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/astroid/node_classes.py", line 357, in infer
    return self._explicit_inference(self, context, **kwargs)
  File "/home/senko/.virtualenvs/pylint-django/lib/python3.6/site-packages/astroid/__init__.py", line 95, in _inference_tip_cached
    result = func(*args, **kwargs)
  File "/home/senko/pylint-django/pylint_django/transforms/foreignkey.py", line 111, in infer_key_classes
    raise RuntimeError("DJANGO_SETTINGS_MODULE required for resolving ForeignKey "
RuntimeError: DJANGO_SETTINGS_MODULE required for resolving ForeignKey string references, see Usage section in README!
```
