### PR TITLE
Changelog for v2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Version 2.3.0 (05 Aug 2020)
+---------------------------
+
+- Improvement in error message for ``missing-backwards-migration-callable``
+  (Bryan Mutai)
+- Start testing with Django 3.1 on Python 3.8
+- Better error message when Django is not configured. Closes
+  `#277 <https://github.com/PyCQA/pylint-django/issues/277>`_
+
+
 Version 2.2.0 (22 Jul 2020)
 ---------------------------
 

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -110,7 +110,8 @@ def infer_key_classes(node, context=None):
                     module_name += '.models'
                 except ImproperlyConfigured:
                     raise RuntimeError("DJANGO_SETTINGS_MODULE required for resolving ForeignKey "
-                                       "string references, see Usage section in README!")
+                                       "string references, see Usage section in README at "
+                                       "https://pypi.org/project/pylint-django/!")
 
                 # ensure that module is loaded in astroid_cache, for cases when models is a package
                 if module_name not in MANAGER.astroid_cache:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email='code@landscape.io',
     description='A Pylint plugin to help Pylint understand the Django web framework',
     long_description=LONG_DESCRIPTION,
-    version='2.2.0',
+    version='2.3.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
@carlio I am reluctant to call this 3.0 b/c I expect pylint will move to v3 at some point, likely introducing incompatibilities and we'll probably have a version mismatch at that point. 

It's fine by me to not precisely follow SemVer every time. I can release a new build today if you agree with that.