### PR TITLE
Update `forms.py` to fix #284

### DIFF
--- a/pylint_django/checkers/forms.py
+++ b/pylint_django/checkers/forms.py
@@ -1,5 +1,5 @@
 """Models."""
-from astroid.nodes import Assign, ClassDef
+from astroid.nodes import Assign, AssignName, ClassDef
 
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers.utils import check_messages
@@ -41,14 +41,10 @@ class FormChecker(BaseChecker):
             return
 
         for child in meta.get_children():
-            if not isinstance(child, Assign):
+            if (not isinstance(child, Assign)
+                    or not isinstance(child.targets[0], AssignName)):
                 continue
 
-            # Capture and ignore AttributeError raised when targets[0] does not
-            # have an attribute "name"
-            try:
-                if child.targets[0].name == 'exclude':
-                    self.add_message('W%s04' % BASE_ID, node=child)
-                    break
-            except AttributeError:
-                pass
+            if child.targets[0].name == 'exclude':
+                self.add_message('W%s04' % BASE_ID, node=child)
+                break

--- a/pylint_django/checkers/forms.py
+++ b/pylint_django/checkers/forms.py
@@ -44,6 +44,11 @@ class FormChecker(BaseChecker):
             if not isinstance(child, Assign):
                 continue
 
-            if child.targets[0].name == 'exclude':
-                self.add_message('W%s04' % BASE_ID, node=child)
-                break
+            # Capture and ignore AttributeError raised when targets[0] does not
+            # have an attribute "name"
+            try:
+                if child.targets[0].name == 'exclude':
+                    self.add_message('W%s04' % BASE_ID, node=child)
+                    break
+            except AttributeError:
+                pass

--- a/pylint_django/tests/input/func_noerror_forms_py33.py
+++ b/pylint_django/tests/input/func_noerror_forms_py33.py
@@ -31,3 +31,12 @@ class TestFormSubclass(forms.Form):
 class TestModelFormSubclass(forms.ModelForm):
     class Meta:
         pass
+
+
+class TestFormWidgetAssignment(forms.Form):
+
+    multi_field = forms.MultipleChoiceField(choices=[('1', 'First'), ('2', 'Second')])
+
+    class Meta:
+        widgets = {}
+        widgets['multi_field'] = forms.CheckboxSelectMultiple


### PR DESCRIPTION
An exception `AttributeError` is raised when `child.targets[0]` does not have an attribute `name`, as stated in the issue #284 .

`meta.get_children()` returns all children of the `Meta` class, which in the sample code contains a dictionary assignment.

The expected children are of type `Assign` whose first item in the attribute `targets` is of type `AssignName`, like `AssignName.widgets(name='widgets')`.

An instruction like `widget["field"] = forms.SomeWidget` will result in a `Assign` child containing a `Subscript(ctx=<Context.Store: 2>, value=<Name.widgets ...>, slice=<Index ...>)`. This is of course unexpected.

I guess other unexpected instructions in the `Meta` class can trigger similar errors, so probably the most economic solution is to enclose the code in `try... except` and ignore the `AttributeError`. Trying to identify the type of object before accessing the `name` attribute would probably incur in a slower execution.