### PR TITLE
Improved Django settings handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 
 after_success:
   - |
-        if [ -z "$SANITY_CHECK" ]; then
+        if [ -z "$SANITY_CHECK" ] && [ -z "$TOXENV" ]; then
             pip install coveralls
             coveralls
         fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 2.3.1 (TBD)
+-------------------
+
+- Allowed configuration of the Django settings module to be used via a
+  commandline argument `#286 <https://github.com/PyCAQ/pylint-django/issues/286>`_
+- If Django settings are not specified via a commandline argument or environment
+  variable, an error is issued but defaults are loaded from Django, removing the
+  fatal error behaviour. `#277 <https://github.com/PyCAQ/pylint-django/issues/277>`__
+  and `#243 <https://github.com/PyCAQ/pylint-django/issues/243>`__
+- Fixed tests to work with pylint>2.6
+
 Version 2.3.0 (05 Aug 2020)
 ---------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,21 @@ about missing Django!
 Usage
 -----
 
-Ensure ``pylint-django`` is installed and on your path and then execute::
+
+Ensure ``pylint-django`` is installed and on your path. In order to access some
+of the internal Django features to improve pylint inspections, you should also
+provide a Django settings module appropriate to your project. This can be done
+either with an environment variable::
 
     DJANGO_SETTINGS_MODULE=your.app.settings pylint --load-plugins pylint_django [..other options..] <path_to_your_sources>
 
+Alternatively, this can be passed in as a commandline flag::
+
+    pylint --load-plugins pylint_django --django-settings-module=your.app.settings [..other options..] <path_to_your_sources>
+
+If you do not configure Django, default settings will be used but this will not include, for
+example, which applications to include in `INSTALLED_APPS` and so the linting and type inference
+will be less accurate. It is recommended to specify a settings module.
 
 Prospector
 ----------

--- a/pylint_django/checkers/__init__.py
+++ b/pylint_django/checkers/__init__.py
@@ -4,6 +4,7 @@ from pylint_django.checkers.models import ModelChecker
 from pylint_django.checkers.json_response import JsonResponseChecker
 from pylint_django.checkers.forms import FormChecker
 from pylint_django.checkers.auth_user import AuthUserChecker
+from pylint_django.checkers.foreign_key_strings import ForeignKeyStringsChecker
 
 
 def register_checkers(linter):
@@ -13,3 +14,4 @@ def register_checkers(linter):
     linter.register_checker(JsonResponseChecker(linter))
     linter.register_checker(FormChecker(linter))
     linter.register_checker(AuthUserChecker(linter))
+    linter.register_checker(ForeignKeyStringsChecker(linter))

--- a/pylint_django/checkers/django_installed.py
+++ b/pylint_django/checkers/django_installed.py
@@ -26,5 +26,5 @@ class DjangoInstalledChecker(BaseChecker):
         except ImportError:
             # mild hack: this error is added before any modules have been inspected
             # so we need to set some kind of value to prevent the linter failing to it
-            self.linter.set_current_module('project global')
+            self.linter.set_current_module('pylint_django')
             self.add_message('django-not-available')

--- a/pylint_django/checkers/django_installed.py
+++ b/pylint_django/checkers/django_installed.py
@@ -20,8 +20,11 @@ class DjangoInstalledChecker(BaseChecker):
     }
 
     @check_messages('django-not-available')
-    def close(self):
+    def open(self):
         try:
             __import__('django')
         except ImportError:
-            self.add_message('F%s01' % BASE_ID)
+            # mild hack: this error is added before any modules have been inspected
+            # so we need to set some kind of value to prevent the linter failing to it
+            self.linter.set_current_module('project global')
+            self.add_message('django-not-available')

--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers.utils import check_messages
+from pylint_django.__pkginfo__ import BASE_ID
+from pylint_django.transforms import foreignkey
+import astroid
+
+
+class ForeignKeyStringsChecker(BaseChecker):
+    """
+    Adds transforms to be able to do type inference for model ForeignKeyField
+    properties which use a string to name the foreign relationship. This uses
+    Django's model name resolution and this checker wraps the setup to ensure
+    Django is able to configure itself before attempting to use the lookups.
+    """
+
+    _LONG_MESSAGE = """Finding foreign-key relationships from strings in pylint-django requires configuring Django.
+This can be done via the DJANGO_SETTINGS_MODULE environment variable or the pylint option django-settings-module, eg:
+
+    `pylint --load-plugins=pylint_django --django-settings-module=myproject.settings`
+
+. This can also be set as an option in a .pylintrc configuration file.
+
+Some basic default settings were used, however this will lead to less accurate linting.
+Consider passing in an explicit Django configuration file to match your project to improve accuracy."""
+
+    __implements__ = (IAstroidChecker,)
+
+    name = "Django foreign keys referenced by strings"
+
+    options = (
+        (
+            "django-settings-module",
+            {
+                "default": None,
+                "type": "string",
+                "metavar": "<django settings module>",
+                "help": "A module containing Django settings to be used while linting.",
+            },
+        ),
+    )
+
+    msgs = {"E%s10" % BASE_ID: ("Django was not configured. For more information run pylint --load-plugins=pylint_django --help-msg=django-not-configured", "django-not-configured", _LONG_MESSAGE),
+    "F%s10" % BASE_ID: (
+        'Provided Django settings %s could not be loaded',
+        'django-settings-module-not-found',
+        'The provided Django settings module %s was not found on the path'
+    )}
+
+    def open(self):
+        self._raise_warning = False
+        # This is a bit of a hacky workaround. pylint-django does not *require* that
+        # Django is configured explicitly, and will use some basic defaults in that
+        # case. However, as this is a WARNING not a FATAL, the error must be raised
+        # with an AST node - only F and R messages are scope exempt (see
+        # https://github.com/PyCQA/pylint/blob/master/pylint/constants.py#L24)
+
+        # However, testing to see if Django is configured happens in `open()`
+        # before any modules are inspected, as Django needs to be configured with
+        # defaults before the foreignkey checker can work properly. At this point,
+        # there are no nodes.
+
+        # Therefore, during the initialisation in `open()`, if django was configured
+        # using defaults by pylint-django, it cannot raise the warning yet and
+        # must wait until some module is inspected to be able to raise... so that
+        # state is stashed in this property.
+
+        from django.core.exceptions import (
+            ImproperlyConfigured,
+        )  # pylint: disable=import-outside-toplevel
+
+        try:
+            import django  # pylint: disable=import-outside-toplevel
+
+            django.setup()
+            from django.apps import apps  # pylint: disable=import-outside-toplevel
+        except ImproperlyConfigured:
+            # this means that Django wasn't able to configure itself using some defaults
+            # provided (likely in a DJANGO_SETTINGS_MODULE environment variable)
+            # so see if the user has specified a pylint option
+            if self.config.django_settings_module is None:
+                # we will warn the user that they haven't actually configured Django themselves
+                self._raise_warning = True
+                # but use django defaults then...
+                from django.conf import settings  # pylint: disable=import-outside-toplevel
+                settings.configure()
+                django.setup()
+            else:
+                # see if we can load the provided settings module
+                try:
+                    from django.conf import settings, Settings  # pylint: disable=import-outside-toplevel
+                    settings.configure(Settings(self.config.django_settings_module))
+                    django.setup()
+                except ImportError:
+                    # we could not find the provided settings module...
+                    # at least here it is a fatal error so we can just raise this immediately
+                    self.add_message('django-settings-module-not-found', args=self.config.django_settings_module)
+                    # however we'll trundle on with basic settings
+                    from django.conf import settings  # pylint: disable=import-outside-toplevel
+                    settings.configure()
+                    django.setup()
+
+        # now we can add the trasforms speciifc to this checker
+        foreignkey.add_transform(astroid.MANAGER)
+
+        # TODO: this is a bit messy having so many inline imports but in order to avoid
+        # duplicating the django_installed checker, it'll do for now. In the future, merging
+        # those two checkers together might make sense.
+
+
+    @check_messages("django-not-configured")
+    def visit_module(self, node):
+        if self._raise_warning:
+            # just add it to the first node we see... which isn't nice but not sure what else to do
+            self.add_message("django-not-configured", node=node)
+            self._raise_warning = False  # only raise it once...

--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -127,7 +127,7 @@ Consider passing in an explicit Django configuration file to match your project 
                     settings.configure()
                     django.setup()
 
-        # now we can add the trasforms speciifc to this checker
+        # now we can add the trasforms specifc to this checker
         foreignkey.add_transform(astroid.MANAGER)
 
         # TODO: this is a bit messy having so many inline imports but in order to avoid

--- a/pylint_django/checkers/migrations.py
+++ b/pylint_django/checkers/migrations.py
@@ -156,7 +156,7 @@ def is_in_migrations(node):
     return is_migrations_module(node.parent)
 
 
-def load_configuration(linter):
+def load_configuration(linter):  # TODO this is redundant and can be  removed
     # don't blacklist migrations for this checker
     new_black_list = list(linter.config.black_list)
     if 'migrations' in new_black_list:

--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -18,7 +18,6 @@ from pylint_django.transforms import fields
 fields.add_transforms(astroid.MANAGER)
 
 
-
 def _add_transform(package_name):
     def fake_module_builder():
         """

--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -1,14 +1,22 @@
-"""Transforms."""
+"""
+These transforms replace the Django types with adapted versions to provide
+additional typing and method inference to pylint. All of these transforms
+are considered "global" to pylint-django, in that all checks and improvements
+requre them to be loaded. Additional transforms specific to checkers are loaded
+by the checker rather than here.
+
+For example, the ForeignKeyStringsChecker loads the foreignkey.py transforms
+itself as it may be disabled independently of the rest of pylint-django
+"""
 import os
 import re
 
 import astroid
 
-from pylint_django.transforms import foreignkey, fields
+from pylint_django.transforms import fields
 
-
-foreignkey.add_transform(astroid.MANAGER)
 fields.add_transforms(astroid.MANAGER)
+
 
 
 def _add_transform(package_name):

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -108,10 +108,10 @@ def infer_key_classes(node, context=None):
                     # 'auth.models', 'User' which works nicely with the `endswith()`
                     # comparison below
                     module_name += '.models'
-                except ImproperlyConfigured:
+                except ImproperlyConfigured as exep:
                     raise RuntimeError("DJANGO_SETTINGS_MODULE required for resolving ForeignKey "
                                        "string references, see Usage section in README at "
-                                       "https://pypi.org/project/pylint-django/!")
+                                       "https://pypi.org/project/pylint-django/!") from exep
 
                 # ensure that module is loaded in astroid_cache, for cases when models is a package
                 if module_name not in MANAGER.astroid_cache:

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -8,7 +8,7 @@ from astroid.nodes import ClassDef
 
 from pylint_django.compat import Uninferable
 
-PY3 = sys.version_info >= (3, 0)
+PY3 = sys.version_info >= (3, 0)  # TODO: pylint_django doesn't support Py2 any more
 
 
 def node_is_subclass(cls, *subclass_names):

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,7 +69,7 @@ echo "..... Trying to install the new tarball inside a virtualenv"
 # note: installs with the optional dependency to verify this is still working
 virtualenv .venv/test-tarball
 source .venv/test-tarball/bin/activate
-pip install --no-binary :all: -f dist/ pylint_django[with_django]
+pip install -f dist/ pylint_django[with_django]
 pip freeze | grep Django
 deactivate
 rm -rf .venv/

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
 [testenv]
 commands =
     django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
-    django_is_installed: pylint --load-plugins=pylint_django setup.py
+    django_is_installed: pylint --load-plugins=pylint_django --disable=E5110 setup.py
     flake8: flake8
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'


### PR DESCRIPTION
This revisits #277 and #243 @atodorov @alejandro-angulo 

I had a new attempt atdealing with django settings required by the foreign key string handling and came up with this solution:

1) as currently, if `DJANGO_SETTINGS_MODULE` is specified, those settings will be used.
2) a commandline option can be used instead - for example `pylint --load-plugins=pylint_django --django-settings-module=myproject.settings` which I assume would work from a `.pylintrc` too.
3) if neither of these are set, then Django is configured using the default settings. In this case, an error message is emitted (`E5110`) instructing the user to configure Django manually to improve linting. I set this as ERROR because it's more severe than just a warning since it is kind of an error in the testing (not in the code being tested, but the testing CI setup). It is not fatal, however, as it can continue to run.

This is done by moving the Foreign Key checks into a checker rather than loading the transforms in when the plugin is loaded. This allows for using the `open()` "setup" method to do any pre-check startup, in this case, running the Django `settings.configure()` method manually rather than allowing Django to do it by itself if it has an environment variable.

Using a checker also means that a commandline option can be used as an additional option for configuring Django settings, which will allow it to be used in pre-commit for example (thus fixing #286)

Note: this also had to remove the `--no-binary :all: ` from the `scripts/build.sh`  sanity check because it seems that a newer release of isort (which pylint depends on) requires clikit and when `--no-binary` is used, pylint-django fails to install. I'm not sure of the consequences of this but I assume that if pylint needs it to install, we have to accept that. This is not related to the main contents of the PR, just something I had to do to get the latest versions to pass CI.