### PR TITLE
Remove old Python2 compatability code and bump release major version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Version 2.3.1 (TBD)
+Version 3.0.0 (TBD)
 -------------------
 
 - Allowed configuration of the Django settings module to be used via a
@@ -11,6 +11,8 @@ Version 2.3.1 (TBD)
   fatal error behaviour. `#277 <https://github.com/PyCAQ/pylint-django/issues/277>`__
   and `#243 <https://github.com/PyCAQ/pylint-django/issues/243>`__
 - Fixed tests to work with pylint>2.6
+- Removed compatibility layer for Python2 and older versions of Django since
+pylint, pylint-django and Django do not support Python2 any more. `#288 <https://github.com/PyCAQ/pylint-django/issues/288>`_
 
 Version 2.3.0 (05 Aug 2020)
 ---------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,9 @@ Version 3.0.0 (TBD)
   fatal error behaviour. `#277 <https://github.com/PyCAQ/pylint-django/issues/277>`__
   and `#243 <https://github.com/PyCAQ/pylint-django/issues/243>`__
 - Fixed tests to work with pylint>2.6
-- Removed compatibility layer for Python2 and older versions of Django since
-pylint, pylint-django and Django do not support Python2 any more. `#288 <https://github.com/PyCAQ/pylint-django/issues/288>`_
+- Removed compatibility layer for Python2 and older versions of Django since pylint,
+  pylint-django and Django do not support Python2 any more.
+  `#288 <https://github.com/PyCAQ/pylint-django/issues/288>`_
 
 Version 2.3.0 (05 Aug 2020)
 ---------------------------

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -26,7 +26,7 @@ from django.views.generic.edit import DeletionMixin, FormMixin, ModelFormMixin
 from django.views.generic.list import MultipleObjectMixin, MultipleObjectTemplateResponseMixin
 from django.utils import termcolors
 
-from pylint_django.utils import node_is_subclass, PY3
+from pylint_django.utils import node_is_subclass
 
 
 # Note: it would have been nice to import the Manager object from Django and
@@ -307,8 +307,7 @@ def ignore_import_warnings_for_related_fields(orig_method, self, node):
 
     new_things = {}
 
-    iterat = consumer.to_consume.items if PY3 else consumer.to_consume.iteritems
-    for name, stmts in iterat():
+    for name, stmts in consumer.to_consume.items():
         if isinstance(stmts[0], ImportFrom):
             if any([n[0] in ('ForeignKey', 'OneToOneField') for n in stmts[0].names]):
                 continue

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -18,7 +18,7 @@ from pylint.checkers.variables import ScopeConsumer
 
 from pylint_plugin_utils import augment_visit, suppress_message
 
-from django import VERSION as django_version
+from django import VERSION as DJANGO_VERSION
 from django.views.generic.base import View, RedirectView, ContextMixin
 from django.views.generic.dates import DateMixin, DayMixin, MonthMixin, WeekMixin, YearMixin
 from django.views.generic.detail import SingleObjectMixin, SingleObjectTemplateResponseMixin, TemplateResponseMixin
@@ -721,7 +721,7 @@ def is_urls_module_valid_constant(node):
 
 
 def allow_meta_protected_access(node):
-    if django_version >= (1, 8):
+    if DJANGO_VERSION >= (1, 8):
         return node.attrname == '_meta'
 
     return False

--- a/pylint_django/checkers/models.py
+++ b/pylint_django/checkers/models.py
@@ -112,7 +112,7 @@ class ModelChecker(BaseChecker):
                 # this model declares a __str__ method so we can stop checking
                 return
 
-            elif method.parent != node:
+            if method.parent != node:
                 # this happens if a parent declares the str method but
                 # this node does not
                 self.add_message("W%s03" % BASE_ID, args=node.name, node=node)

--- a/pylint_django/checkers/models.py
+++ b/pylint_django/checkers/models.py
@@ -12,29 +12,42 @@ from pylint_django.utils import node_is_subclass
 
 
 MESSAGES = {
-    'E%d01' % BASE_ID: ("__str__ on a model must be callable (%s)",
-                        'model-unicode-not-callable',
-                        "Django models require a callable __str__ method"),
-    'W%d01' % BASE_ID: ("No __str__ method on model (%s)",
-                        'model-missing-unicode',
-                        "Django models should implement a __str__ method for string representation (see https://docs.djangoproject.com/en/3.1/ref/models/instances/#django.db.models.Model.__str__)"),
-    'W%d02' % BASE_ID: ("Found __unicode__ method on model (%s). Python3 uses __str__.",
-                        'model-has-unicode',
-                        "Django models should not implement a __unicode__ "
-                        "method for string representation when using Python3"),
-    'W%d03' % BASE_ID: ("Model does not explicitly define __str__ (%s)",
-                        'model-no-explicit-unicode',
-                        "Django models should implement a __str__ method for string representation. "
-                        "A parent class of this model does, but ideally all models should be explicit.")
+    "E%d01"
+    % BASE_ID: (
+        "__str__ on a model must be callable (%s)",
+        "model-unicode-not-callable",
+        "Django models require a callable __str__ method",
+    ),
+    "W%d01"
+    % BASE_ID: (
+        "No __str__ method on model (%s)",
+        "model-missing-unicode",
+        "Django models should implement a __str__ method for string representation "
+        "(see https://docs.djangoproject.com/en/3.1/ref/models/instances/#django.db.models.Model.__str__)",
+    ),
+    "W%d02"
+    % BASE_ID: (
+        "Found __unicode__ method on model (%s). Python3 uses __str__.",
+        "model-has-unicode",
+        "Django models should not implement a __unicode__ "
+        "method for string representation when using Python3",
+    ),
+    "W%d03"
+    % BASE_ID: (
+        "Model does not explicitly define __str__ (%s)",
+        "model-no-explicit-unicode",
+        "Django models should implement a __str__ method for string representation. "
+        "A parent class of this model does, but ideally all models should be explicit.",
+    ),
 }
 
 
 def _is_meta_with_abstract(node):
-    if isinstance(node, ClassDef) and node.name == 'Meta':
+    if isinstance(node, ClassDef) and node.name == "Meta":
         for meta_child in node.get_children():
             if not isinstance(meta_child, Assign):
                 continue
-            if not meta_child.targets[0].name == 'abstract':
+            if not meta_child.targets[0].name == "abstract":
                 continue
             if not isinstance(meta_child.value, Const):
                 continue
@@ -52,17 +65,19 @@ def _has_python_2_unicode_compatible_decorator(node):
         return False
 
     for decorator in node.decorators.nodes:
-        if getattr(decorator, 'name', None) == 'python_2_unicode_compatible':
+        if getattr(decorator, "name", None) == "python_2_unicode_compatible":
             return True
 
     return False
 
 
 def _is_unicode_or_str_in_python_2_compatibility(method):
-    if method.name == '__unicode__':
+    if method.name == "__unicode__":
         return True
 
-    if method.name == '__str__' and _has_python_2_unicode_compatible_decorator(method.parent):
+    if method.name == "__str__" and _has_python_2_unicode_compatible_decorator(
+        method.parent
+    ):
         return True
 
     return False
@@ -70,15 +85,16 @@ def _is_unicode_or_str_in_python_2_compatibility(method):
 
 class ModelChecker(BaseChecker):
     """Django model checker."""
+
     __implements__ = IAstroidChecker
 
-    name = 'django-model-checker'
+    name = "django-model-checker"
     msgs = MESSAGES
 
-    @check_messages('model-missing-unicode')
+    @check_messages("model-missing-unicode")
     def visit_classdef(self, node):
         """Class visitor."""
-        if not node_is_subclass(node, 'django.db.models.base.Model', '.Model'):
+        if not node_is_subclass(node, "django.db.models.base.Model", ".Model"):
             # we only care about models
             return
 
@@ -93,7 +109,7 @@ class ModelChecker(BaseChecker):
                     continue
 
                 name = grandchildren[0].name
-                if name != '__str__':
+                if name != "__str__":
                     continue
 
                 grandchild = grandchildren[1]
@@ -102,21 +118,23 @@ class ModelChecker(BaseChecker):
                 if assigned.callable():
                     return
 
-                self.add_message('E%s01' % BASE_ID, args=node.name, node=node)
+                self.add_message("E%s01" % BASE_ID, args=node.name, node=node)
                 return
 
-            if isinstance(child, FunctionDef) and child.name == '__unicode__':
-                self.add_message('W%s02' % BASE_ID, args=node.name, node=node)
+            if isinstance(child, FunctionDef) and child.name == "__unicode__":
+                self.add_message("W%s02" % BASE_ID, args=node.name, node=node)
                 return
 
         # if we get here, then we have no __str__ method directly on the class itself
 
         # a different warning is emitted if a parent declares __str__
         for method in node.methods():
-            if method.parent != node and _is_unicode_or_str_in_python_2_compatibility(method):
+            if method.parent != node and _is_unicode_or_str_in_python_2_compatibility(
+                method
+            ):
                 # this happens if a parent declares the unicode method but
                 # this node does not
-                self.add_message('W%s03' % BASE_ID, args=node.name, node=node)
+                self.add_message("W%s03" % BASE_ID, args=node.name, node=node)
                 return
 
         # if the Django compatibility decorator is used then we don't emit a warning

--- a/pylint_django/tests/input/external_django_tables2_noerror_meta_class.py
+++ b/pylint_django/tests/input/external_django_tables2_noerror_meta_class.py
@@ -2,7 +2,7 @@
 # don't produce old-style-class warnings, see
 # https://github.com/PyCQA/pylint-django/issues/56
 
-# pylint: disable=missing-docstring,too-few-public-methods
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring,too-few-public-methods
 
 from django.db import models
 import django_tables2 as tables

--- a/pylint_django/tests/input/external_drf_noerror_serializer.py
+++ b/pylint_django/tests/input/external_drf_noerror_serializer.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about DRF serializers
 """
-#  pylint: disable=C0111,W5101
+# pylint: disable=model-no-explicit-str,C0111,W5101
 
 from rest_framework import serializers
 

--- a/pylint_django/tests/input/external_factory_boy_noerror.py
+++ b/pylint_django/tests/input/external_factory_boy_noerror.py
@@ -2,7 +2,7 @@
 Test to validate that pylint_django doesn't produce
 Instance of 'SubFactory' has no 'pk' member (no-member) warnings
 """
-# pylint: disable=attribute-defined-outside-init, missing-docstring, too-few-public-methods
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,attribute-defined-outside-init, missing-docstring, too-few-public-methods
 import factory
 
 from django import test

--- a/pylint_django/tests/input/external_factory_boy_noerror.py
+++ b/pylint_django/tests/input/external_factory_boy_noerror.py
@@ -2,7 +2,8 @@
 Test to validate that pylint_django doesn't produce
 Instance of 'SubFactory' has no 'pk' member (no-member) warnings
 """
-# pylint: disable=model-no-explicit-str,model-no-explicit-str,attribute-defined-outside-init, missing-docstring, too-few-public-methods
+# pylint: disable=model-no-explicit-str,model-no-explicit-str
+# pylint: disable=attribute-defined-outside-init, missing-docstring, too-few-public-methods
 import factory
 
 from django import test

--- a/pylint_django/tests/input/external_model_utils_noerror_override_manager.py
+++ b/pylint_django/tests/input/external_model_utils_noerror_override_manager.py
@@ -2,7 +2,7 @@
 # with a manager from the django-model-utils package pylint-django
 # does not report not-an-iterator error, see
 # https://github.com/PyCQA/pylint-django/issues/117
-# pylint: disable=missing-docstring, invalid-name
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, invalid-name
 
 from model_utils.managers import InheritanceManager
 

--- a/pylint_django/tests/input/external_psycopg2_noerror_postgres_fields.py
+++ b/pylint_django/tests/input/external_psycopg2_noerror_postgres_fields.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain Postgres model fields.
 """
-#  pylint: disable=C0111,W5101
+# pylint: disable=model-no-explicit-str,C0111,W5101
 from __future__ import print_function
 
 from django.contrib.postgres import fields

--- a/pylint_django/tests/input/func_hard_coded_auth_user.py
+++ b/pylint_django/tests/input/func_hard_coded_auth_user.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, wildcard-import, unused-wildcard-import
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, wildcard-import, unused-wildcard-import
 # flake8: noqa=F401, F403
 
 from django.db import models

--- a/pylint_django/tests/input/func_json_response.py
+++ b/pylint_django/tests/input/func_json_response.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, line-too-long
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, line-too-long
 
 import json
 from django import http

--- a/pylint_django/tests/input/func_model_does_not_use_unicode_py33.py
+++ b/pylint_django/tests/input/func_model_does_not_use_unicode_py33.py
@@ -1,7 +1,7 @@
 """
 Ensures that under PY3 django models with a __unicode__ method are flagged
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.py
+++ b/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.py
@@ -3,17 +3,15 @@ Ensures that django models with a __str__ method defined in an ancestor and
 python_2_unicode_compatible decorator applied are flagged correctly as not
 having explicitly defined __unicode__
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=missing-docstring
 
 from django.db import models
-from six import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class BaseModel(models.Model):
     def __str__(self):
         return 'Foo'
 
 
-class SomeModel(BaseModel):  # [model-no-explicit-unicode]
+class SomeModelX(BaseModel):  # [model-no-explicit-str]
     pass

--- a/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.txt
+++ b/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.txt
@@ -1,1 +1,1 @@
-model-no-explicit-unicode:18:SomeModel:Model does not explicitly define __unicode__ (SomeModel)
+model-no-explicit-unicode:18:SomeModel:Model does not explicitly define __str__ (SomeModel)

--- a/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.txt
+++ b/pylint_django/tests/input/func_model_no_explicit_unicode_str_compat.txt
@@ -1,1 +1,1 @@
-model-no-explicit-unicode:18:SomeModel:Model does not explicitly define __str__ (SomeModel)
+model-no-explicit-str:16:SomeModelX:Model does not explicitly define __str__ (SomeModelX)

--- a/pylint_django/tests/input/func_modelform_exclude.py
+++ b/pylint_django/tests/input/func_modelform_exclude.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint complains about ModelForm using exclude
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django import forms
 
 

--- a/pylint_django/tests/input/func_noerror_classviews.py
+++ b/pylint_django/tests/input/func_noerror_classviews.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about attributes and methods
 when using Class-based Views
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 from django.db import models
 from django.http import JsonResponse

--- a/pylint_django/tests/input/func_noerror_duplicate_except_doesnotexist.py
+++ b/pylint_django/tests/input/func_noerror_duplicate_except_doesnotexist.py
@@ -3,7 +3,7 @@ Checks that Pylint does not complain about duplicate
 except blocks catching DoesNotExist exceptions:
 https://github.com/PyCQA/pylint-django/issues/81
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_factory_post_generation.py
+++ b/pylint_django/tests/input/func_noerror_factory_post_generation.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about no self argument in
 factory.post_generation method.
 """
-#  pylint: disable=missing-docstring,too-few-public-methods,unused-argument,no-member
+# pylint: disable=model-no-explicit-str,missing-docstring,too-few-public-methods,unused-argument,no-member
 import factory
 
 

--- a/pylint_django/tests/input/func_noerror_foreign_key_attributes.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_attributes.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about foreign key sets on models
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_foreign_key_ids.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_ids.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about foreign key id access
 """
-#  pylint: disable=missing-docstring,wrong-import-position
+# pylint: disable=model-no-explicit-str,missing-docstring,wrong-import-position
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_foreign_key_key_cls_unbound.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_key_cls_unbound.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about ForeignKey pointing to model
 in module of models package
 """
-# pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_foreign_key_package.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_package.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about ForeignKey pointing to model
 in module of models package
 """
-# pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_foreign_key_sets.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_sets.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about foreign key sets on models
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_foreignkeys.py
+++ b/pylint_django/tests/input/func_noerror_foreignkeys.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about various
 methods on Django model fields.
 """
-#  pylint: disable=missing-docstring,wrong-import-position
+# pylint: disable=model-no-explicit-str,missing-docstring,wrong-import-position
 from django.db import models
 from django.db.models import ForeignKey, OneToOneField
 

--- a/pylint_django/tests/input/func_noerror_form_fields.py
+++ b/pylint_django/tests/input/func_noerror_form_fields.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about various
 methods on Django form forms.
 """
-#  pylint: disable=missing-docstring,R0904
+# pylint: disable=model-no-explicit-str,missing-docstring,R0904
 from __future__ import print_function
 from datetime import datetime, date
 from django import forms

--- a/pylint_django/tests/input/func_noerror_forms_py33.py
+++ b/pylint_django/tests/input/func_noerror_forms_py33.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about django Forms
 """
-#  pylint: disable=missing-docstring,wrong-import-position
+# pylint: disable=model-no-explicit-str,missing-docstring,wrong-import-position
 
 from django import forms
 

--- a/pylint_django/tests/input/func_noerror_formview_ancestors.py
+++ b/pylint_django/tests/input/func_noerror_formview_ancestors.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about django FormViews
 having too many ancestors
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django.views.generic import FormView
 
 

--- a/pylint_django/tests/input/func_noerror_generic_foreign_key.py
+++ b/pylint_django/tests/input/func_noerror_generic_foreign_key.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about GenericForeignKey fields:
 https://github.com/PyCQA/pylint-django/issues/230
 """
-# pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring
 
 from django.db import models
 from django.contrib.contenttypes.models import ContentType

--- a/pylint_django/tests/input/func_noerror_ignore_meta_subclass.py
+++ b/pylint_django/tests/input/func_noerror_ignore_meta_subclass.py
@@ -2,7 +2,7 @@
 This test ensures that a 'Meta' class defined on a Django model does
 not raise warnings such as 'old-style-class' and 'too-few-public-methods'
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_import_q.py
+++ b/pylint_django/tests/input/func_noerror_import_q.py
@@ -1,5 +1,5 @@
 """
 Checks that Pylint does not complain about import of Q.
 """
-#  pylint: disable=missing-docstring,unused-import
+# pylint: disable=model-no-explicit-str,missing-docstring,unused-import
 from django.db.models import Q  # noqa: F401

--- a/pylint_django/tests/input/func_noerror_issue_46.py
+++ b/pylint_django/tests/input/func_noerror_issue_46.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about raising DoesNotExist
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_managers_return_querysets.py
+++ b/pylint_django/tests/input/func_noerror_managers_return_querysets.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about Manager methods returning lists
 when they in fact return QuerySets
 """
-
+# pylint: disable=model-no-explicit-str
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_manytomanyfield.py
+++ b/pylint_django/tests/input/func_noerror_manytomanyfield.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about various
 methods on many-to-many relationships
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django.db import models
 from django.contrib.auth.models import AbstractUser, Permission
 
@@ -31,7 +31,7 @@ class Author(models.Model):
 USER_PERMS = ['change_customuser', 'add_customuser']
 
 
-class CustomUser(AbstractUser):  # pylint: disable=model-no-explicit-unicode
+class CustomUser(AbstractUser):
     class Meta:
         verbose_name = 'CustomUser'
         verbose_name_plural = 'CustomUsers'

--- a/pylint_django/tests/input/func_noerror_model_fields.py
+++ b/pylint_django/tests/input/func_noerror_model_fields.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about various
 methods on Django model fields.
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from __future__ import print_function
 from datetime import datetime, date
 from decimal import Decimal

--- a/pylint_django/tests/input/func_noerror_model_methods.py
+++ b/pylint_django/tests/input/func_noerror_model_methods.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about using Model and Manager methods
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_model_objects.py
+++ b/pylint_django/tests/input/func_noerror_model_objects.py
@@ -2,7 +2,7 @@
 # doesn't raise issues, see
 # https://github.com/PyCQA/pylint-django/issues/144
 #
-# pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_model_unicode_callable.py
+++ b/pylint_django/tests/input/func_noerror_model_unicode_callable.py
@@ -1,7 +1,7 @@
 """
 Ensures that django models without a __unicode__ method are flagged
 """
-#  pylint: disable=missing-docstring,wrong-import-position
+# pylint: disable=model-no-explicit-str,missing-docstring,wrong-import-position
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_model_unicode_lambda.py
+++ b/pylint_django/tests/input/func_noerror_model_unicode_lambda.py
@@ -1,7 +1,7 @@
 """
 Ensures that django models without a __unicode__ method are flagged
 """
-#  pylint: disable=missing-docstring,wrong-import-position
+# pylint: disable=model-no-explicit-str,missing-docstring,wrong-import-position
 
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_models_py33.py
+++ b/pylint_django/tests/input/func_noerror_models_py33.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about a fairly standard
 Django Model
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_protected_meta_access.py
+++ b/pylint_django/tests/input/func_noerror_protected_meta_access.py
@@ -5,7 +5,7 @@ Django 1.8
 (see https://github.com/PyCQA/pylint-django/issues/66,
 and https://docs.djangoproject.com/en/1.9/ref/models/meta/)
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from __future__ import print_function
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_string_foreignkey.py
+++ b/pylint_django/tests/input/func_noerror_string_foreignkey.py
@@ -2,7 +2,7 @@
 Checks that PyLint correctly handles string foreign keys
 https://github.com/PyCQA/pylint-django/issues/243
 """
-# pylint: disable=missing-docstring, hard-coded-auth-user
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, hard-coded-auth-user
 from django.db import models
 
 

--- a/pylint_django/tests/input/func_noerror_style_members.py
+++ b/pylint_django/tests/input/func_noerror_style_members.py
@@ -1,7 +1,7 @@
 # Test that using `color_style` or `no_style`
 # doesn't raise no-member error
 #
-# pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring
 
 from django.core.management.color import color_style, no_style
 

--- a/pylint_django/tests/input/func_noerror_test_wsgi_request.py
+++ b/pylint_django/tests/input/func_noerror_test_wsgi_request.py
@@ -10,6 +10,9 @@ from django.db import models
 class SomeModel(models.Model):
     """Just a model."""
 
+    def __str__(self):
+        return str(self.id)
+
 
 class SomeTestCase(TestCase):
     """A test cast."""
@@ -19,3 +22,6 @@ class SomeTestCase(TestCase):
         response = self.client.get('/get/some/thing/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['object'], expected_object)
+
+    def __str__(self):
+        return str(self.id)

--- a/pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
+++ b/pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
@@ -4,7 +4,7 @@ Django python3/2 compatability dectorator is used
 
 See https://github.com/PyCQA/pylint-django/issues/10
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 from six import python_2_unicode_compatible
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_urls.py
+++ b/pylint_django/tests/input/func_noerror_urls.py
@@ -2,7 +2,7 @@
 Checks that Pylint does not complain about attributes and methods
 when creating a typical urls.py
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 from django.views.generic import TemplateView
 from django.conf.urls import url

--- a/pylint_django/tests/input/func_noerror_uuid_field.py
+++ b/pylint_django/tests/input/func_noerror_uuid_field.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain about UUID fields.
 """
-#  pylint: disable=C0111,W5101
+# pylint: disable=model-no-explicit-str,C0111,W5101
 from __future__ import print_function
 from django.db import models
 

--- a/pylint_django/tests/input/func_noerror_views.py
+++ b/pylint_django/tests/input/func_noerror_views.py
@@ -1,7 +1,7 @@
 """
 Checks that Pylint does not complain when using function based views.
 """
-#  pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,missing-docstring
 
 
 def empty_view(request):

--- a/pylint_django/tests/input/func_unused_arguments.py
+++ b/pylint_django/tests/input/func_unused_arguments.py
@@ -2,7 +2,7 @@
 Checks that Pylint still complains about unused-arguments for other
 arguments if a function/method contains an argument named `request`.
 """
-# pylint: disable=missing-docstring
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring
 
 from django.http import JsonResponse
 from django.views import View
@@ -12,7 +12,7 @@ from django.views import View
 # warning will not be generated.
 # Therefore define request here to cover this behaviour in this test case.
 
-request = None  # pylint: disable=invalid-name
+request = None  # pylint: disable=model-no-explicit-str,model-no-explicit-str,invalid-name
 
 
 def user_detail(request, user_id):  # [unused-argument]

--- a/pylint_django/tests/input/migrations/0001_noerror_initial.py
+++ b/pylint_django/tests/input/migrations/0001_noerror_initial.py
@@ -1,7 +1,7 @@
 """
 Initial migration which should not raise any pylint warnings.
 """
-# pylint: disable=missing-docstring, invalid-name
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, invalid-name
 from django.db import migrations, models
 
 

--- a/pylint_django/tests/input/migrations/0002_new_column.py
+++ b/pylint_django/tests/input/migrations/0002_new_column.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/2.0/topics/migrations/#postgresql
 > For this reason, it’s recommended you always create new columns with
 > null=True, as this way they will be added immediately.
 """
-# pylint: disable=missing-docstring, invalid-name
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, invalid-name
 from datetime import timedelta
 from django.db import migrations, models
 

--- a/pylint_django/tests/input/migrations/0003_without_backwards.py
+++ b/pylint_django/tests/input/migrations/0003_without_backwards.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, invalid-name
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, invalid-name
 from django.db import migrations
 
 

--- a/pylint_django/tests/input/migrations/0004_noerror_with_backwards.py
+++ b/pylint_django/tests/input/migrations/0004_noerror_with_backwards.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring, invalid-name
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, invalid-name
 from django.db import migrations
 
 

--- a/pylint_django/tests/input/models/author.py
+++ b/pylint_django/tests/input/models/author.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,wrong-import-position
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring,wrong-import-position
 from django.db import models
 
 

--- a/pylint_django/tests/input/models/func_noerror_foreign_key_key_cls_unbound_in_same_package.py
+++ b/pylint_django/tests/input/models/func_noerror_foreign_key_key_cls_unbound_in_same_package.py
@@ -10,7 +10,7 @@ Hence it can't find the Author class here so it tells us it doesn't have an
 'id' attribute. Also see:
 https://github.com/PyCQA/pylint-django/issues/232#issuecomment-495242695
 """
-# pylint: disable=missing-docstring, no-member
+# pylint: disable=model-no-explicit-str,model-no-explicit-str,missing-docstring, no-member
 from django.db import models
 
 

--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -67,15 +67,7 @@ def apply_type_shim(cls, _context=None):  # noqa
     else:
         return iter([cls])
 
-    # XXX: for some reason, with python3, this particular line triggers a
-    # check in the StdlibChecker for deprecated methods; one of these nodes
-    # is an ImportFrom which has no qname() method, causing the checker
-    # to die...
-    if utils.PY3:
-        base_nodes = [n for n in base_nodes[1] if not isinstance(n, nodes.ImportFrom)]
-    else:
-        base_nodes = list(base_nodes[1])
-
+    base_nodes = [n for n in base_nodes[1] if not isinstance(n, nodes.ImportFrom)]
     return iter([cls] + base_nodes)
 
 

--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -3,8 +3,6 @@ from astroid import (
     AstroidImportError
 )
 
-from pylint_django import utils
-
 
 _STR_FIELDS = ('CharField', 'SlugField', 'URLField', 'TextField', 'EmailField',
                'CommaSeparatedIntegerField', 'FilePathField', 'GenericIPAddressField',

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -1,5 +1,4 @@
 """Utils."""
-import sys
 import astroid
 
 from astroid.bases import Instance

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -8,8 +8,6 @@ from astroid.nodes import ClassDef
 
 from pylint_django.compat import Uninferable
 
-PY3 = sys.version_info >= (3, 0)  # TODO: pylint_django doesn't support Py2 any more
-
 
 def node_is_subclass(cls, *subclass_names):
     """Checks if cls node has parent with subclass_name."""

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email='code@landscape.io',
     description='A Pylint plugin to help Pylint understand the Django web framework',
     long_description=LONG_DESCRIPTION,
-    version='2.3.0',
+    version='3.0.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
     django_is_installed: pylint --load-plugins=pylint_django --disable=E5110 setup.py
     flake8: flake8
-    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
+    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme,duplicate-code --ignore=tests pylint_django setup
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django22: coverage run pylint_django/tests/test_func.py -v

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     django_not_installed: bash -c \'pylint --load-plugins=pylint_django setup.py | grep django-not-available\'
     django_is_installed: pylint --load-plugins=pylint_django --disable=E5110 setup.py
     flake8: flake8
-    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme,duplicate-code --ignore=tests pylint_django setup
+    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
     py{35,36,37}-django22: coverage run pylint_django/tests/test_func.py -v


### PR DESCRIPTION
This is addressing #288 

There are several conditionals relating to Python 2 compatibility that are no longer necessary now that latest pylint, pylint-django and Django do not support python2. Additionally, Django 3 removed compatibility APIs too  (see https://docs.djangoproject.com/en/3.1/releases/3.0/#removed-private-python-2-compatibility-apis)

This PR cleans up all of those things to remove code that (as far as I know) isn't useful to keep around.

As a side-effect, I suggest bumping the pylint-django major version to match the Django one, since this likely has a few backwards-incompatible changes (probably a few extra warnings about `__str__` and `__unicode__` might appear for some users). If you disagree I'm happy to remove that part of this change!