### PR TITLE
Remove unecessary migrations blacklisting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Version 2.3.1 (TBD)
   fatal error behaviour. `#277 <https://github.com/PyCAQ/pylint-django/issues/277>`__
   and `#243 <https://github.com/PyCAQ/pylint-django/issues/243>`__
 - Fixed tests to work with pylint>2.6
+- Cleaned up some redundant (and possibly unused) blacklist management surrounding
+  linting of DB migrations `#289 <https://github.com/PyCQA/pylint-django/issues/289>_`
 
 Version 2.3.0 (05 Aug 2020)
 ---------------------------

--- a/pylint_django/checkers/migrations.py
+++ b/pylint_django/checkers/migrations.py
@@ -156,20 +156,10 @@ def is_in_migrations(node):
     return is_migrations_module(node.parent)
 
 
-def load_configuration(linter):  # TODO this is redundant and can be  removed
-    # don't blacklist migrations for this checker
-    new_black_list = list(linter.config.black_list)
-    if 'migrations' in new_black_list:
-        new_black_list.remove('migrations')
-    linter.config.black_list = new_black_list
-
-
 def register(linter):
     """Required method to auto register this checker."""
     linter.register_checker(NewDbFieldWithDefaultChecker(linter))
     linter.register_checker(MissingBackwardsMigrationChecker(linter))
-    if not compat.LOAD_CONFIGURATION_SUPPORTED:
-        load_configuration(linter)
 
     # apply augmentations for migration checkers
     # Unused arguments for migrations

--- a/pylint_django/checkers/migrations.py
+++ b/pylint_django/checkers/migrations.py
@@ -17,7 +17,6 @@ from pylint.checkers import utils
 from pylint_plugin_utils import suppress_message
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django import compat
 from pylint_django.utils import is_migrations_module
 
 

--- a/pylint_django/plugin.py
+++ b/pylint_django/plugin.py
@@ -18,9 +18,6 @@ def load_configuration(linter):
     name_checker.config.good_names += ('qs', 'urlpatterns', 'register', 'app_name',
                                        'handler400', 'handler403', 'handler404', 'handler500')
 
-    # we don't care about South migrations
-    linter.config.black_list += ('migrations', 'south_migrations')
-
 
 def register(linter):
     """


### PR DESCRIPTION
From what I can see, the process is:

1) pylint loads the pylint_django plugin and runs `load_configuration` (or, using compat, we do it) and we add `migrations` to the `linter.config.blacklist` : https://github.com/PyCQA/pylint-django/blob/7721691d73a26fea3d4c7e23b90d5cc8ad9c6f96/pylint_django/plugin.py#L13
2) pylint_django loads its list of checkers including the migrations checker, which removess `migrations` from `linter.config.blacklist` : https://github.com/PyCQA/pylint-django/blob/7721691d73a26fea3d4c7e23b90d5cc8ad9c6f96/pylint_django/checkers/migrations.py#L159

So basically we add it to the blacklist then remove it almost immediately. I think from the comment that the migrations checker is trying to only remove it for its own checks, but the linter config is global so I believe that this code is unused and has no effect.

Since it probably also interferes with any user-provided configuration in their `.pylintrc`, and as far as I can tell it hasn't caused any problems that everything checks `migrations` folders, I think we should remove the code to clean up as I think it's essentially a no-op