### PR TITLE
Remove false positive error of missing member in TextChoices tuples

### DIFF
--- a/pylint_django/tests/input/func_noerror_model_enum.py
+++ b/pylint_django/tests/input/func_noerror_model_enum.py
@@ -1,0 +1,23 @@
+"""
+Test that django TextChoices does not raise a warning due to .label and .value methods
+"""
+#  pylint: disable=missing-docstring,too-few-public-methods
+
+from django.db import models
+
+
+class SomeTextChoices(models.TextChoices):
+    CHOICE_A = ("choice_a", "Choice A")
+    CHOICE_B = ("choice_b", "Choice B")
+    CHOICE_C = ("choice_c", "Choice C")
+
+
+class SomeClass():
+    choice_values = [
+        SomeTextChoices.CHOICE_A.value,
+        SomeTextChoices.CHOICE_B.value,
+    ]
+    choice_labels = [
+        SomeTextChoices.CHOICE_B.label,
+        SomeTextChoices.CHOICE_C.label,
+    ]


### PR DESCRIPTION
Why:

- The fields label and value are not marked as missing

This change addresses the need by:

- Adding a test to ensure that pylint does not mark these as errors