### PR TITLE
Fix for Reverse Manager `update_or_create` calls

### DIFF
--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -44,6 +44,7 @@ MANAGER_ATTRS = {
     'extra',
     'get',
     'get_or_create',
+    'update_or_create',
     'get_queryset',
     'create',
     'bulk_create',

--- a/pylint_django/tests/input/func_noerror_foreign_key_sets.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_sets.py
@@ -15,6 +15,9 @@ class SomeModel(models.Model):
     def get_first(self):
         return self.othermodel_set.first()
 
+    def othermodel_update_or_create(self):
+        return self.othermodel_set.update_or_create()
+
 
 class OtherModel(models.Model):
     count = models.IntegerField()


### PR DESCRIPTION
This attr list appears to be missing `update_or_create` which means that reverse related managers throw an error when trying to use them like `self.<MANAGER>.update_or_create()`.