### PR TITLE
Pin Faker to Prevent Asteroid Crash and Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'Operating System :: Unix',
         'Topic :: Software Development :: Quality Assurance',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         'pylint-plugin-utils>=0.5',
         'pylint>=2.0',
+        'Faker==5.0.1',
     ],
     extras_require={
         'with_django': ['Django'],

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     pylint
     readme
     py{36}-django{111,20,-master}
-    py{35,36,37}-django22
+    py{36,37}-django22
     py{36,37,38}-django{30,31}
 
 [testenv]
@@ -20,7 +20,7 @@ commands =
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django setup
     readme: bash -c \'python setup.py -q sdist && twine check dist/*\'
     py{36}-django{111,20,-master}: coverage run pylint_django/tests/test_func.py -v
-    py{35,36,37}-django22: coverage run pylint_django/tests/test_func.py -v
+    py{36,37}-django22: coverage run pylint_django/tests/test_func.py -v
     py{36,37,38}-django{30,31}: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
@@ -47,7 +47,7 @@ whitelist_externals =
     django_not_installed: bash
     readme: bash
     py{36}-django{111,20,-master}: coverage
-    py{35,36,37}-django22: coverage
+    py{36,37}-django22: coverage
     py{36,37,38}-django{30,31}: coverage
     clean: find
     clean: rm


### PR DESCRIPTION
There's some sort of issue with version 5.0.2 of Faker which updates a
lot of code to use the pathlib library instead of os utils. This causes
the sys.path_importer_cache to get filled with PosixPath objects instead
of strings as it's keys, which causes an asteroid crash.

For now, we can just pin Faker to a version that still works until the
upstream issue is resolved.