### PR TITLE
Relaxed Faker package versioning requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'pylint-plugin-utils>=0.5',
         'pylint>=2.0',
-        'Faker==5.0.1',
+        'Faker<=5.0.1',
     ],
     extras_require={
         'with_django': ['Django'],


### PR DESCRIPTION
As per https://github.com/PyCQA/pylint-django/issues/302. This still avoids Faker version 5.0.2, but will better avoid dependencies clashes with projects that uses pylint-django along with Faker.