### PR TITLE
Move Faker dependency to tests-only

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.4.2 (08 Jan 2021)
+---------------------------
+
+- Moved `Faker` dependencies to test-only `#304 <https://github.com/PyCQA/pylint-django/issues/304>`_
+
+
 Version 2.4.1 (07 Jan 2021)
 ---------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email='code@landscape.io',
     description='A Pylint plugin to help Pylint understand the Django web framework',
     long_description=LONG_DESCRIPTION,
-    version='2.4.1',
+    version='2.4.2',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,10 @@ setup(
     install_requires=[
         'pylint-plugin-utils>=0.5',
         'pylint>=2.0',
-        'Faker<=5.0.1',
     ],
     extras_require={
         'with_django': ['Django'],
-        'for_tests': ['django_tables2', 'factory-boy', 'coverage', 'pytest'],
+        'for_tests': ['django_tables2', 'factory-boy', 'coverage', 'pytest', 'Faker<=5.0.1'],
     },
     license='GPLv2',
     classifiers=[


### PR DESCRIPTION
Related to #304 - the Faker dependency is only for the CI and testing, it should not be a dependency for pylint-django users.