### PR TITLE
Include 'all' as a field attribute of ManyToMany relationships.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+Version 2.4.3 (05 Mar 2021)
+---------------------------
+
+- Added `all` to available ManyToMany field attributes. (@ypcrumble)
+
+
 Version 2.4.2 (08 Jan 2021)
 ---------------------------
 

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -247,6 +247,7 @@ FOREIGNKEY_FIELD_ATTRS = {
 
 MANYTOMANY_FIELD_ATTRS = {
     'add',
+    'all',
     'clear',
     'related_name',
     'related_query_name',

--- a/pylint_django/tests/input/func_noerror_manytomanyfield.py
+++ b/pylint_django/tests/input/func_noerror_manytomanyfield.py
@@ -45,6 +45,9 @@ class CustomUser(AbstractUser):  # pylint: disable=model-no-explicit-unicode
             self.user_permissions.add(perm)
         return self.user_permissions
 
+    def get_permissions(self):
+        self.user_permissions.all()
+
     def add_permission(self, permission):
         self.user_permissions.add(permission)
 


### PR DESCRIPTION
Thanks for maintaining this great repo! This is really an issue, but the fix is easy so thought it better to post as a PR. If I've missed something feel free to close. 

Per [the docs](https://docs.djangoproject.com/en/3.1/topics/db/examples/many_to_many/) It's possible to call `all()` on a many to many attribute. For example, the docs call `a1.publications.all()` in their example.

I'm seeing this error pop up which I don't believe is a configuration error.