### PR TITLE
Add all default methods to view subclass validation function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 Unreleased
 ----------
 
-- Start testing with Django 3.2 on Python 3.9
+- Start testing with Django 3.2 on Python 3.9 (Michael K.)
+- Teach pylint-django about all HTTP methods from the View class, not only
+  ``get`` and ``post`` (Nicolás Quiroz)
 
 
 Version 2.4.2 (08 Jan 2021)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Unreleased
 - Start testing with Django 3.2 on Python 3.9 (Michael K.)
 - Teach pylint-django about all HTTP methods from the View class, not only
   ``get`` and ``post`` (Nicolás Quiroz)
+- Ignore ``unused-argument`` for ``*args``, ``**kwards`` in view method signatures
 
 
 Version 2.4.2 (08 Jan 2021)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,4 +16,5 @@
 * [WayneLambert](https://github.com/WayneLambert)
 * [alejandro-angulo](https://github.com/alejandro-angulo)
 * [brymut](https://github.com/brymut)
-
+* [michael-k](https://github.com/michael-k)
+* [naquiroz](https://github.com/naquiroz)

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -652,7 +652,7 @@ def ignore_unused_argument_warnings_for_request(orig_method, self, stmt, name):
     The signature of Django view functions require the request argument but it is okay if the request is not used.
     This function should be used as a wrapper for the `VariablesChecker._is_name_ignored` method.
     """
-    if name == 'request':
+    if name in ('request', 'args', 'kwargs'):
         return True
 
     return orig_method(self, stmt, name)

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -630,8 +630,8 @@ def generic_is_view_attribute(parents, attrs):
 
 
 def is_model_view_subclass_method_shouldnt_be_function(node):
-    """Checks that node is get or post method of the View class."""
-    if node.name not in ('get', 'post'):
+    """Checks that node is a default http method (i.e get, post, put, and more) of the View class."""
+    if node.name not in View.http_method_names:
         return False
 
     parent = node.parent

--- a/pylint_django/tests/input/func_noerror_classviews.py
+++ b/pylint_django/tests/input/func_noerror_classviews.py
@@ -58,7 +58,7 @@ class JsonHeadView(View):
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
-class JsonOptionsSView(View):
+class JsonOptionsView(View):
     def options(self, request):
         # do something with objects but don't use
         # self or request

--- a/pylint_django/tests/input/func_noerror_classviews.py
+++ b/pylint_django/tests/input/func_noerror_classviews.py
@@ -21,13 +21,54 @@ class BoringView(TemplateView):
             'kwargs': self.kwargs
         }
 
+    
+class JsonGetView(View):
+    def get(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
 
-class JsonView(View):
+class JsonPostView(View):
     def post(self, request):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
+class JsonPutView(View):
+    def put(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
+
+class JsonPatchView(View):
+    def patch(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
+
+class JsonDeleteView(View):
+    def delete(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
+
+class JsonHeadView(View):
+    def head(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
+
+class JsonOptionsSView(View):
+    def options(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
+
+class JsonTraceView(View):
+    def trace(self, request):
+        # do something with objects but don't use
+        # self or request
+        return JsonResponse({'rc': 0, 'response': 'ok'})
 
 class Book(models.Model):
     name = models.CharField(max_length=100)

--- a/pylint_django/tests/input/func_noerror_classviews.py
+++ b/pylint_django/tests/input/func_noerror_classviews.py
@@ -21,12 +21,13 @@ class BoringView(TemplateView):
             'kwargs': self.kwargs
         }
 
-    
+
 class JsonGetView(View):
     def get(self, request):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
+
 
 class JsonPostView(View):
     def post(self, request):
@@ -34,11 +35,13 @@ class JsonPostView(View):
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
+
 class JsonPutView(View):
     def put(self, request):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
+
 
 class JsonPatchView(View):
     def patch(self, request):
@@ -46,11 +49,13 @@ class JsonPatchView(View):
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
+
 class JsonDeleteView(View):
     def delete(self, request):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
+
 
 class JsonHeadView(View):
     def head(self, request):
@@ -58,17 +63,20 @@ class JsonHeadView(View):
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
+
 class JsonOptionsView(View):
     def options(self, request):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
+
 class JsonTraceView(View):
     def trace(self, request):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
+
 
 class Book(models.Model):
     name = models.CharField(max_length=100)

--- a/pylint_django/tests/input/func_noerror_classviews.py
+++ b/pylint_django/tests/input/func_noerror_classviews.py
@@ -23,56 +23,56 @@ class BoringView(TemplateView):
 
 
 class JsonGetView(View):
-    def get(self, request):
+    def get(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonPostView(View):
-    def post(self, request):
+    def post(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonPutView(View):
-    def put(self, request):
+    def put(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonPatchView(View):
-    def patch(self, request):
+    def patch(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonDeleteView(View):
-    def delete(self, request):
+    def delete(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonHeadView(View):
-    def head(self, request):
+    def head(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonOptionsView(View):
-    def options(self, request):
+    def options(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})
 
 
 class JsonTraceView(View):
-    def trace(self, request):
+    def trace(self, request, *args, **kwargs):
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})

--- a/pylint_django/tests/input/func_noerror_classviews.py
+++ b/pylint_django/tests/input/func_noerror_classviews.py
@@ -58,7 +58,7 @@ class JsonDeleteView(View):
 
 
 class JsonHeadView(View):
-    def head(self, request, *args, **kwargs):
+    def head(self, request, *args, **kwargs):  # pylint: disable=method-hidden
         # do something with objects but don't use
         # self or request
         return JsonResponse({'rc': 0, 'response': 'ok'})


### PR DESCRIPTION
This pull request adds all the Django's **View** class default HTTP methods to the `is_model_view_subclass_method_shouldnt_be_function`.