### PR TITLE
Fix pylint 2.8.0 compatibility

### DIFF
--- a/pylint_django/compat.py
+++ b/pylint_django/compat.py
@@ -24,5 +24,6 @@ except ImportError:
 
 import pylint
 
-# pylint before version 2.3 does not support load_configuration() hook.
-LOAD_CONFIGURATION_SUPPORTED = pylint.__pkginfo__.numversion >= (2, 3)
+# pylint before version 2.3 does not support load_configuration() hook.'
+# The __pkginfo__.numversion attribute was removed in pylint >= 2.8.0
+LOAD_CONFIGURATION_SUPPORTED = pylint.__pkginfo__.numversion >= (2, 3) if hasattr(pylint.__pkginfo__, "numversion") else True

--- a/pylint_django/compat.py
+++ b/pylint_django/compat.py
@@ -25,6 +25,6 @@ except ImportError:
 import pylint
 
 # The __pkginfo__.numversion attribute was removed in pylint >= 2.8.0
-_pylint_version = pylint.__pkginfo__.numversion if hasattr(pylint.__pkginfo__, "numversion") else pylint.__pkginfo__.version
+_pylint_version = pylint.__pkginfo__.version if hasattr(pylint.__pkginfo__, "version") else pylint.__pkginfo__.numversion
 # pylint before version 2.3 does not support load_configuration() hook.'
 LOAD_CONFIGURATION_SUPPORTED = _pylint_version >= (2, 3)

--- a/pylint_django/compat.py
+++ b/pylint_django/compat.py
@@ -24,6 +24,7 @@ except ImportError:
 
 import pylint
 
-# pylint before version 2.3 does not support load_configuration() hook.'
 # The __pkginfo__.numversion attribute was removed in pylint >= 2.8.0
-LOAD_CONFIGURATION_SUPPORTED = pylint.__pkginfo__.numversion >= (2, 3) if hasattr(pylint.__pkginfo__, "numversion") else True
+_pylint_version = pylint.__pkginfo__.numversion if hasattr(pylint.__pkginfo__, "numversion") else pylint.__pkginfo__.version
+# pylint before version 2.3 does not support load_configuration() hook.'
+LOAD_CONFIGURATION_SUPPORTED = _pylint_version >= (2, 3)


### PR DESCRIPTION
numversion was removed from pkginfo in pylint:
see: https://github.com/PyCQA/pylint/commit/fbcb27acb3431cea846bbfb997f411e51417d1bb#diff-42df8bb8e2d7b0a18f0174dcb5f3c60b1cbca5a394c3c7f8c9b33c99fb6cda99L34

The following error shows up if using latest version of pylint & pylint-django:
```
File "/home/toolchain/.cache/pants/named_caches/pex_root/venvs/short/90e31a6e/lib/python3.7/site-packages/pylint_django/__init__.py", line 6, in <module>
    from pylint_django import plugin
  File "/home/toolchain/.cache/pants/named_caches/pex_root/venvs/short/90e31a6e/lib/python3.7/site-packages/pylint_django/plugin.py", line 5, in <module>
    from pylint_django.checkers import register_checkers
  File "/home/toolchain/.cache/pants/named_caches/pex_root/venvs/short/90e31a6e/lib/python3.7/site-packages/pylint_django/checkers/__init__.py", line 3, in <module>
    from pylint_django.checkers.models import ModelChecker
  File "/home/toolchain/.cache/pants/named_caches/pex_root/venvs/short/90e31a6e/lib/python3.7/site-packages/pylint_django/checkers/models.py", line 11, in <module>
    from pylint_django.utils import node_is_subclass, PY3
  File "/home/toolchain/.cache/pants/named_caches/pex_root/venvs/short/90e31a6e/lib/python3.7/site-packages/pylint_django/utils.py", line 9, in <module>
    from pylint_django.compat import Uninferable
  File "/home/toolchain/.cache/pants/named_caches/pex_root/venvs/short/90e31a6e/lib/python3.7/site-packages/pylint_django/compat.py", line 28, in <module>
    LOAD_CONFIGURATION_SUPPORTED = pylint.__pkginfo__.numversion >= (2, 3)
AttributeError: module 'pylint.__pkginfo__' has no attribute 'numversion'

```

Signed-off-by: Asher Foa <asher@asherfoa.com>