### PR TITLE
Make the ForeiginKey detection more accurate

### DIFF
--- a/pylint_django/tests/input/external_tastypie_noerror_foreign_key.py
+++ b/pylint_django/tests/input/external_tastypie_noerror_foreign_key.py
@@ -1,0 +1,20 @@
+"""
+Checks that Pylint doesn't raise an error when a 'ForeignKey' appears in a
+non-django class
+
+The real case is described as follow:
+The project use tastypie and django.
+tastypie has a `ForeignKey` field which has the same name
+as django's `ForeignKey`.
+The issue is the lint trys resolving the `ForeignKey` for the
+tastypie `ForeignKey` which cause import error.
+"""
+# pylint: disable=missing-docstring
+from tastypie.resources import ModelResource
+from tastypie import fields
+from tastypie.fields import ForeignKey
+
+
+class MyTestResource(ModelResource): # pylint: disable=too-few-public-methods
+    field1 = ForeignKey('myapp.api.resource', 'xxx')
+    field2 = fields.ForeignKey('myapp.api.resource', 'xxx')

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -16,6 +16,15 @@ def is_foreignkey_in_class(node):
     if not isinstance(node.parent.parent, ClassDef):
         return False
 
+    # Make sure the outfit class is the subclass of django.db.models.Model
+    is_in_django_model_class = node_is_subclass(
+        node.parent.parent,
+        'django.db.models.base.Model',
+        '.Model'
+    )
+    if not is_in_django_model_class:
+        return False
+
     if isinstance(node.func, Attribute):
         attr = node.func.attrname
     elif isinstance(node.func, nodes.Name):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     extras_require={
         'with_django': ['Django'],
-        'for_tests': ['django_tables2', 'factory-boy', 'coverage', 'pytest'],
+        'for_tests': ['django_tables2', 'factory-boy', 'coverage', 'pytest', 'django-tastypie'],
     },
     license='GPLv2',
     classifiers=[


### PR DESCRIPTION
we have a `api.py` which contains a tastypie resource, pylint regonized the resource's `ForeiginKey` as django's `ForeiginKey` by mistake, and then cause an error.
```python
class SavedSearchesResource(ModelResource):
    owner = fields.ForeignKey(
        "user.api.UserResource",
        "owner",
        readonly=True,
    )
```

In this commit, add a check to ensure the current class of the
`ForeignKey` is a subclass of `Model` of django.

Tested manually

Test case:
Before the fix, the new test case failed
![image](https://user-images.githubusercontent.com/29817206/132333494-9f210c30-2c25-4f69-985f-47f610d372c9.png)


After the fix, the test case passed:

![image](https://user-images.githubusercontent.com/29817206/132333418-ffed1b2d-7954-4a9d-9472-b8e0262b123c.png)

