### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Additional plugins
 
 - add new model fields and these fields have a default value. According to
   `Django docs <https://docs.djangoproject.com/en/2.0/topics/migrations/#postgresql>`_
-  this may have performance penalties especially on large tables. The prefered way
+  this may have performance penalties especially on large tables. The preferred way
   is to add a new DB column with ``null=True`` because it will be created instantly
   and then possibly populate the table with the desired default values.
   Only the last migration from a sub-directory will be examined;

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -757,7 +757,7 @@ def pylint_newstyle_classdef_compat(linter, warning_name, augment):
 
 def apply_wrapped_augmentations():
     """
-    Apply augmentation and supression rules through monkey patching of pylint.
+    Apply augmentation and suppression rules through monkey patching of pylint.
     """
     # NOTE: The monkey patching is done with wrap and needs to be done in a thread safe manner to support the
     # parallel option of pylint (-j).

--- a/pylint_django/checkers/migrations.py
+++ b/pylint_django/checkers/migrations.py
@@ -49,7 +49,7 @@ class NewDbFieldWithDefaultChecker(checkers.BaseChecker):
     especially on large tables:
     https://docs.djangoproject.com/en/2.0/topics/migrations/#postgresql
 
-    The prefered way is to add a new DB column with null=True because it will
+    The preferred way is to add a new DB column with null=True because it will
     be created instantly and then possibly populate the table with the
     desired default values.
     """

--- a/pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
+++ b/pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
@@ -1,6 +1,6 @@
 """
 Ensures that no '__unicode__ missing' warning is emitted if the
-Django python3/2 compatability dectorator is used
+Django python3/2 compatability decorator is used
 
 See https://github.com/PyCQA/pylint-django/issues/10
 """

--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -22,7 +22,7 @@ def _add_transform(package_name):
     def fake_module_builder():
         """
             Build a fake module to use within transformations.
-            @package_name is a parameter from the outher scope b/c according to
+            @package_name is a parameter from the other scope b/c according to
             the docs this can't receive any parameters.
             http://pylint.pycqa.org/projects/astroid/en/latest/extending.html?highlight=MANAGER#module-extender-transforms
         """

--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -22,7 +22,7 @@ def _add_transform(package_name):
     def fake_module_builder():
         """
             Build a fake module to use within transformations.
-            @package_name is a parameter from the other scope b/c according to
+            @package_name is a parameter from the outer scope b/c according to
             the docs this can't receive any parameters.
             http://pylint.pycqa.org/projects/astroid/en/latest/extending.html?highlight=MANAGER#module-extender-transforms
         """

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -120,7 +120,7 @@ def infer_key_classes(node, context=None):
             # create list from dict_values, because it may be modified in a loop
             for module in list(MANAGER.astroid_cache.values()):
                 # only load model classes from modules which match the module in
-                # which *we think* they are defined. This will prevent infering
+                # which *we think* they are defined. This will prevent inferring
                 # other models of the same name which are found elsewhere!
                 if model_name in module.locals and module.name.endswith(module_name):
                     class_defs = _get_model_class_defs_from_module(


### PR DESCRIPTION
There are small typos in:
- README.rst
- pylint_django/augmentations/__init__.py
- pylint_django/checkers/migrations.py
- pylint_django/tests/input/func_noerror_unicode_py2_compatible.py
- pylint_django/transforms/__init__.py
- pylint_django/transforms/foreignkey.py

Fixes:
- Should read `preferred` rather than `prefered`.
- Should read `suppression` rather than `supression`.
- Should read `other` rather than `outher`.
- Should read `inferring` rather than `infering`.
- Should read `decorator` rather than `dectorator`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md