### PR TITLE
pylint-plugin-utils version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "pylint-plugin-utils>=0.5",
+        "pylint-plugin-utils>=0.7",
         "pylint>=2.0",
     ],
     extras_require={


### PR DESCRIPTION
Bumping minimum pylint-plugin-utils version to get better multi-processing support - see https://github.com/PyCQA/pylint-plugin-utils/pull/21

(Not really necessary as the version was already `>=0.5` but might as well avoid depending on older versions.)