### PR TITLE
Astroid 2.9.1 scoped_nodes compatibility fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,19 @@ Changelog
 
 Version 2.5 [WIP]
 ---------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Fixed compatability with astroid 2.9.1 (`#343 <https://github.com/PyCQA/pylint-django/issues/343>`_)
+
+New
+~~~
+
 - Moved from Travis CI to GitHub Actions (`#366 <https://github.com/PyCQA/pylint-django/pull/366>`_ and `#340 <https://github.com/PyCQA/pylint-django/pull/340>`_)
-- Added pre-commit configuration and began enforcing black/isort code formatting (TODO: add github action to enforce)
+- Added pre-commit configuration and began enforcing black/isort code formatting
 - Multiple test fixes (including `#338 <https://github.com/PyCQA/pylint-django/issues/338>`_) - newer versions of pylint expect a different format for the expected messages txt files.
-- TODO: Bumped dependency for pylint-django-utils to get `multi-threaded pylint support <https://github.com/PyCQA/pylint-plugin-utils/pull/21>`_
+- Bumped dependency for pylint-django-utils to get `multi-threaded pylint support <https://github.com/PyCQA/pylint-plugin-utils/pull/21>`_
 
 Version 2.4.4 (26 Apr 2021)
 ---------------------------

--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -5,9 +5,9 @@ import itertools
 
 from astroid import InferenceError
 from astroid.nodes import Attribute, ClassDef, ImportFrom
+from astroid.nodes.scoped_nodes import ClassDef as ScopedClass
+from astroid.nodes.scoped_nodes import Module
 from astroid.objects import Super
-from astroid.scoped_nodes import ClassDef as ScopedClass
-from astroid.scoped_nodes import Module
 from django import VERSION as django_version
 from django.utils import termcolors
 from django.views.generic.base import ContextMixin, RedirectView, View

--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -1,4 +1,5 @@
-from astroid import MANAGER, AstroidImportError, inference_tip, nodes, scoped_nodes
+from astroid import MANAGER, AstroidImportError, inference_tip, nodes
+from astroid.nodes import scoped_nodes
 
 from pylint_django import utils
 


### PR DESCRIPTION
`astroid.scoped_nodes` is deprecated and will be moved to `astroid.nodes.scoped_nodes` in astroid 3.0 - see https://github.com/PyCQA/astroid/blob/main/astroid/scoped_nodes.py#L26

However it seems like the release of `2.9.1` moved some members already, so this PR just uses the new locations.

Fixes #343