### PR TITLE
Add "no-member" suppression in WSGIRequest inside Django Test Cases

### DIFF
--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -799,16 +799,15 @@ def is_wsgi_application(node):
 
 def is_wsgi_request(node):
     def is_inside_test_case():
-        test_case_parent = 'django.test.testcases.SimpleTestCase'
+        test_case_parent = "django.test.testcases.SimpleTestCase"
 
         for ancestor in node.node_ancestors():
-            if getattr(ancestor, "type", None) == 'class':
+            if getattr(ancestor, "type", None) == "class":
                 for class_ancestor in ancestor.mro():
                     if class_ancestor.qname() == test_case_parent:
                         return True
 
         return False
-
 
     wsgi_request_parent = "django.core.handlers.wsgi.WSGIRequest"
 


### PR DESCRIPTION
Fixes #332 

Supresses "no-member" for attributes of a WSGIRequest, that is inside a class that inherits from django.test.testcases.SimpleTestCase.

Let me know if you need me to change anything.
Thank you.