### PR TITLE
Set undefined env variables using CLI arguments

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@
 * [naquiroz](https://github.com/naquiroz)
 * [john-sandall](https://github.com/john-sandall)
 * [dineshtrivedi](https://github.com/dineshtrivedi)
+* [TheAfroOfDoom](https://github.com/TheAfroOfDoom)

--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+import os
+
 import astroid
+from configurations import importer
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
@@ -39,6 +42,15 @@ Consider passing in an explicit Django configuration file to match your project 
                 "type": "string",
                 "metavar": "<django settings module>",
                 "help": "A module containing Django settings to be used while linting.",
+            },
+        ),
+        (
+            "django-configuration",
+            {
+                "default": None,
+                "type": "string",
+                "metavar": "<django configuration>",
+                "help": "The configuration for Django to use while linting.",
             },
         ),
     )
@@ -88,6 +100,32 @@ Consider passing in an explicit Django configuration file to match your project 
 
         try:
             import django  # pylint: disable=import-outside-toplevel
+
+            if (
+                os.environ.get("DJANGO_SETTINGS_MODULE") is None
+                or os.environ.get("DJANGO_CONFIGURATION") is None
+            ):
+                try:
+                    os.environ.setdefault(
+                        "DJANGO_SETTINGS_MODULE",
+                        os.environ.get("DJANGO_SETTINGS_MODULE")
+                        or self.config.django_settings_module,
+                    )
+                    os.environ.setdefault(
+                        "DJANGO_CONFIGURATION",
+                        os.environ.get("DJANGO_CONFIGURATION")
+                        or self.config.django_configuration,
+                    )
+                except TypeError as ex:
+                    missing_module = ""
+                    if self.config.django_settings_module is None:
+                        missing_module = "DJANGO_SETTINGS_MODULE"
+                    else:
+                        missing_module = "DJANGO_CONFIGURATION"
+                    raise RuntimeError(
+                        f"{missing_module} required to initialize Django project settings"
+                    ) from ex
+                importer.install()
 
             django.setup()
             from django.apps import (  # noqa pylint: disable=import-outside-toplevel,unused-import


### PR DESCRIPTION
Both `DJANGO_SETTINGS_MODULE` and `DJANGO_CONFIGURATION` are required for `django.configurations.importer` to install, else it throws an exception.
If the `importer` is not installed, `django.setup()` fails on `configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)` when trying to access uninitialized settings.

fixes #309 (https://github.com/PyCQA/pylint-django/issues/309#issuecomment-817098961)
fixes #325
might relate to #362