### PR TITLE
Migrate metadata from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,45 @@
+[metadata]
+name = pylint-django
+version = 2.5.3
+author = landscape.io
+author_email = code@landscape.io
+license = GPLv2
+description = A Pylint plugin to help Pylint understand the Django web framework
+keywords = pylint, django, plugin
+url = https://github.com/PyCQA/pylint-django
+long_description = file: README.rst, CHANGELOG.rst
+classifiers =
+    Environment :: Console
+    Intended Audience :: Developers
+    Operating System :: Unix
+    Topic :: Software Development :: Quality Assurance
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Framework :: Django :: 1.11
+    Framework :: Django :: 2.0
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
+    Framework :: Django :: 3.2
+project_urls =
+    Changelog = https://github.com/PyCQA/pylint-django/blob/master/CHANGELOG.rst
+
+[options]
+packages = find:
+zip_safe = False
+install_requires = pylint-plugin-utils>=0.7; pylint>=2.0,<3
+include_package_data = True
+
+[options.extras_require]
+with_django = Django
+for_tests =
+    django_tables2
+    factory-boy
+    coverage
+    pytest
+    wheel
+    django-tastypie
+    pylint>=2.13

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,4 @@ Setup module for Pylint plugin for Django.
 """
 from setuptools import setup
 
-
 setup()

--- a/setup.py
+++ b/setup.py
@@ -2,58 +2,7 @@
 """
 Setup module for Pylint plugin for Django.
 """
-from setuptools import find_packages, setup
+from setuptools import setup
 
-with open("README.rst", encoding="utf-8") as readme, open("CHANGELOG.rst", encoding="utf-8") as changelog:
-    LONG_DESCRIPTION = readme.read() + "\n" + changelog.read()
 
-setup(
-    name="pylint-django",
-    url="https://github.com/PyCQA/pylint-django",
-    author="landscape.io",
-    author_email="code@landscape.io",
-    description="A Pylint plugin to help Pylint understand the Django web framework",
-    long_description=LONG_DESCRIPTION,
-    version="2.5.3",
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=[
-        "pylint-plugin-utils>=0.7",
-        "pylint>=2.0,<3",
-    ],
-    extras_require={
-        "with_django": ["Django"],
-        "for_tests": [
-            "django_tables2",
-            "factory-boy",
-            "coverage",
-            "pytest",
-            "wheel",
-            "django-tastypie",
-            "pylint>=2.13",
-        ],
-    },
-    license="GPLv2",
-    classifiers=[
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "Operating System :: Unix",
-        "Topic :: Software Development :: Quality Assurance",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
-        "Framework :: Django :: 3.1",
-        "Framework :: Django :: 3.2",
-    ],
-    keywords=["pylint", "django", "plugin"],
-    zip_safe=False,
-    project_urls={
-        "Changelog": "https://github.com/PyCQA/pylint-django/blob/master/CHANGELOG.rst",
-    },
-)
+setup()


### PR DESCRIPTION
Done using https://pypi.org/project/setuptools-py2cfg plus manual modifications.

After this is reviewed and landed, a migration to `pyproject.toml` can be achieved using https://pypi.org/project/ini2toml or similar.