### PR TITLE
add python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     version="2.5.3",
     packages=find_packages(),
     include_package_data=True,
-    python_requires='>=3.6.2',
+    python_requires=">=3.6.2",
     install_requires=[
         "pylint-plugin-utils>=0.7",
         "pylint>=2.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     version="2.5.3",
     packages=find_packages(),
     include_package_data=True,
+    python_requires='>=3.6.2',
     install_requires=[
         "pylint-plugin-utils>=0.7",
         "pylint>=2.0,<3",


### PR DESCRIPTION
setting the keyword argument python_requires is a better way to declare Python compatibility #379 