### PR TITLE
Additional suppressions for classes

### DIFF
--- a/pylint_django/tests/input/external_drf_noerror_serializer.py
+++ b/pylint_django/tests/input/external_drf_noerror_serializer.py
@@ -9,3 +9,7 @@ from rest_framework import serializers
 class TestSerializerSubclass(serializers.ModelSerializer):
     class Meta:
         pass
+
+
+class TestSerializer(serializers.Serializer):
+    pass

--- a/pylint_django/tests/input/func_noerror_docstrings.py
+++ b/pylint_django/tests/input/func_noerror_docstrings.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-class-docstring, missing-module-docstring, too-few-public-methods, missing-function-docstring, no-method-argument, no-self-use, too-many-function-args
+class Parent:
+    def test():
+        return 0
+
+class ChildDoc(Parent):
+    def test():
+        """Difference"""
+        return super().test()


### PR DESCRIPTION
Added two additional suppressions:  
1. Suppress `useless-super-delegation` when docstrings are different in functions as it can be used in generating documentation for example in Swagger.
```py
class NewView(ViewSet):
    def list(self):
        """Documentation"""
         return super().list()
``` 
2. Suppress `abstract-method` when inheriting from `rest_framework.serializers.Serializer`. According to [documentation](https://www.django-rest-framework.org/api-guide/serializers/) overriding `create` and `update` methods is optional.