### PR TITLE
Update versions of Python and Django

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+NOTICE
+~~~~~~
+
+We dropped support for:
+
+- Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1.
+- Python 3.9.
+- pylint below 4.0.
+
+Other
+~~~~~
+
+- CI now only tests against contemporary versions of Django (4.2, 5.1, 5.2, 6.0)
+  and Python (3.10, 3.11, 3.12, 3.13, 3.14).
+
 Version 2.6.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,10 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Framework :: Django :: 2.2",
-  "Framework :: Django :: 3",
-  "Framework :: Django :: 3.0",
-  "Framework :: Django :: 3.1",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4",
-  "Framework :: Django :: 4.0",
-  "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
 ]
 keywords = [ "pylint", "django", "plugin" ]
@@ -42,10 +35,10 @@ include = [ "pylint_django/LICENSE" ]
 exclude = [ "**/tests/**", "**/testutils.py", "**/tests.py" ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 pylint-plugin-utils = ">=0.8"
-pylint = ">=3.0,<4"
-Django = { version = ">=2.2", optional = true }
+pylint = ">=4.0,<5"
+Django = { version = ">=4.2", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 tox = ">=4.9"

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,12 @@ envlist =
     flake8
     pylint
     readme
-    py{39}-django{22,30,31,32}
-    py{39,310,311,312}-django{40,41,42}
-    py{310,311,312}-django{50,51,-main}
+    py{310,311,312}-django{42}
+    py{310,311,312,313}-django{51,52}
+    py{312,313,314}-django{60,-main}
 
 requires =
-    pip >=21.0.1
+    pip >=25.2
     poetry
     tox
 
@@ -21,7 +21,7 @@ commands =
     django_not_installed: bash pylint_django/tests/test_django_not_installed.sh
     pylint: pylint pylint_django
     readme: bash -c "poetry build && twine check dist/*"
-    py{38,39,310,311,312}-django{22,30,31,32,40,41,42,50}: bash scripts/test.sh --cov=pylint_django
+    py{310,311,312,313,314}-django{42,51,52,60}: bash scripts/test.sh --cov=pylint_django
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
@@ -31,15 +31,10 @@ deps =
     pylint: Django
     readme: twine
     readme: wheel
-    django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
-    django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.3,<5.3
+    django60: Django>=6.0,<6.1
     django-main: Django
     django-main: git+https://github.com/pylint-dev/astroid@main
     django-main: git+https://github.com/pylint-dev/pylint@main
@@ -49,6 +44,6 @@ setenv =
 allowlist_externals =
     django_not_installed: bash
     readme: bash
-    django{22,30,31,32,40,41,42,50,51,-main}: bash
+    django{42,51,52,60,-main}: bash
     clean: find
     clean: rm


### PR DESCRIPTION
I did my best at updating the dependencies of Django and Python to only be those that are not EOL (including Django 6.0, which is currently in alpha and expected to land in a couple of months).