### PR TITLE
Use anchor to exclude functional tests in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,9 @@ repos:
     hooks:
       - id: ruff-check
         args: ["--fix"]
-        exclude: "tests/input/"
+        exclude: &functional "tests/input/"
       - id: ruff-format
-        exclude: ^pylint_django/tests/input.*$
+        exclude: *functional
         args: [--line-length=120]
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.11.1"
@@ -40,4 +40,4 @@ repos:
         language: system
         types: [python]
         args: ["-rn", "-sn", "--fail-on=I"]
-        exclude: "tests/input/"
+        exclude: *functional


### PR DESCRIPTION
Easier to add new pre-commit hook or refactor the functional test directory that way.