### PR TITLE
Drop python 2 / pylint 2.0 remnants

### DIFF
--- a/pylint_django/checkers/auth_user.py
+++ b/pylint_django/checkers/auth_user.py
@@ -1,7 +1,7 @@
 from pylint import checkers
+from pylint.checkers.utils import only_required_for_messages
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 
 
 class AuthUserChecker(checkers.BaseChecker):
@@ -20,14 +20,14 @@ class AuthUserChecker(checkers.BaseChecker):
         ),
     }
 
-    @check_messages("hard-coded-auth-user")
+    @only_required_for_messages("hard-coded-auth-user")
     def visit_const(self, node):
         # for now we don't check if the parent is a ForeignKey field
         # because the user model should not be hard-coded anywhere
         if node.value == "auth.User":
             self.add_message("hard-coded-auth-user", node=node)
 
-    @check_messages("imported-auth-user")
+    @only_required_for_messages("imported-auth-user")
     def visit_importfrom(self, node):
         if node.modname == "django.contrib.auth.models":
             for imported_names in node.names:

--- a/pylint_django/checkers/django_installed.py
+++ b/pylint_django/checkers/django_installed.py
@@ -1,7 +1,7 @@
 from pylint.checkers import BaseChecker
+from pylint.checkers.utils import only_required_for_messages
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 
 
 class DjangoInstalledChecker(BaseChecker):
@@ -23,7 +23,7 @@ class DjangoInstalledChecker(BaseChecker):
         ),
     }
 
-    @check_messages("django-not-available")
+    @only_required_for_messages("django-not-available")
     def open(self):
         try:
             __import__("django")

--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -1,8 +1,8 @@
 import astroid
 from pylint.checkers import BaseChecker
+from pylint.checkers.utils import only_required_for_messages
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 from pylint_django.transforms import foreignkey
 
 
@@ -133,7 +133,7 @@ Consider passing in an explicit Django configuration file to match your project 
         # duplicating the django_installed checker, it'll do for now. In the future, merging
         # those two checkers together might make sense.
 
-    @check_messages("django-not-configured")
+    @only_required_for_messages("django-not-configured")
     def visit_module(self, node):
         if self._raise_warning:
             # just add it to the first node we see... which isn't nice but not sure what else to do

--- a/pylint_django/checkers/forms.py
+++ b/pylint_django/checkers/forms.py
@@ -2,9 +2,9 @@
 
 from astroid.nodes import Assign, AssignName, ClassDef
 from pylint.checkers import BaseChecker
+from pylint.checkers.utils import only_required_for_messages
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 from pylint_django.utils import node_is_subclass
 
 
@@ -27,7 +27,7 @@ class FormChecker(BaseChecker):
         )
     }
 
-    @check_messages("modelform-uses-exclude")
+    @only_required_for_messages("modelform-uses-exclude")
     def visit_classdef(self, node):
         """Class visitor."""
         if not node_is_subclass(node, "django.forms.models.ModelForm", ".ModelForm"):

--- a/pylint_django/checkers/json_response.py
+++ b/pylint_django/checkers/json_response.py
@@ -8,9 +8,9 @@ Various suggestions about JSON http responses
 
 import astroid
 from pylint import checkers
+from pylint.checkers.utils import only_required_for_messages
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 
 
 class JsonResponseChecker(checkers.BaseChecker):
@@ -41,7 +41,7 @@ class JsonResponseChecker(checkers.BaseChecker):
         ),
     }
 
-    @check_messages(
+    @only_required_for_messages(
         "http-response-with-json-dumps",
         "http-response-with-content-type-json",
         "redundant-content-type-for-json-response",

--- a/pylint_django/checkers/migrations.py
+++ b/pylint_django/checkers/migrations.py
@@ -10,11 +10,11 @@ pylint --load-plugins=pylint_django.checkers.migrations
 
 import astroid
 from pylint import checkers
+from pylint.checkers.utils import only_required_for_messages
 from pylint_plugin_utils import suppress_message
 
 from pylint_django import compat
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 from pylint_django.utils import is_migrations_module
 
 
@@ -84,7 +84,7 @@ class NewDbFieldWithDefaultChecker(checkers.BaseChecker):
             if node not in self._possible_offences[module]:
                 self._possible_offences[module].append(node)
 
-    @check_messages("new-db-field-with-default")
+    @only_required_for_messages("new-db-field-with-default")
     def close(self):
         def _path(node):
             return node.path
@@ -121,7 +121,7 @@ class MissingBackwardsMigrationChecker(checkers.BaseChecker):
         )
     }
 
-    @check_messages("missing-backwards-migration-callable")
+    @only_required_for_messages("missing-backwards-migration-callable")
     def visit_call(self, node):
         try:
             module = node.frame().parent

--- a/pylint_django/checkers/models.py
+++ b/pylint_django/checkers/models.py
@@ -1,11 +1,10 @@
 """Models."""
 
-from astroid import Const
-from astroid.nodes import Assign, AssignName, ClassDef, FunctionDef
+from astroid.nodes import Assign, AssignName, ClassDef, Const, FunctionDef
 from pylint.checkers import BaseChecker
+from pylint.checkers.utils import only_required_for_messages
 
 from pylint_django.__pkginfo__ import BASE_ID
-from pylint_django.compat import check_messages
 from pylint_django.utils import PY3, node_is_subclass
 
 MESSAGES = {
@@ -78,7 +77,7 @@ class ModelChecker(BaseChecker):
     name = "django-model-checker"
     msgs = MESSAGES
 
-    @check_messages("model-missing-unicode")
+    @only_required_for_messages("model-missing-unicode")
     def visit_classdef(self, node):  # noqa: PLR0911
         """Class visitor."""
         if not node_is_subclass(node, "django.db.models.base.Model", ".Model"):

--- a/pylint_django/compat.py
+++ b/pylint_django/compat.py
@@ -21,11 +21,6 @@ except ImportError:
     except ImportError:
         from astroid.util import Uninferable
 
-try:
-    from pylint.checkers.utils import only_required_for_messages as check_messages
-except (ImportError, ModuleNotFoundError):
-    from pylint.checkers.utils import check_messages
-
 import pylint
 
 # pylint before version 2.3 does not support load_configuration() hook.


### PR DESCRIPTION
pylint-django is not compatible with pylint 2 nor python 2 anymore since some time ago, but some compat layers are still there and have a run time impact as well as a maintenance impact.

Better reviewed commit by commit.