### PR TITLE
Fixes for pylint 4.0+

### DIFF
--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -108,6 +108,12 @@ def apply_type_shim(cls, _context=None):  # pylint: disable=too-many-statements
     else:
         base_nodes = list(base_nodes[1])
 
+    # Add all ancestors inheriting from Field
+    for ancestor in cls.ancestors():
+        if ancestor.qname() == "django.db.models.fields.Field":
+            break
+        base_nodes.append(ancestor)
+
     return iter([cls, *base_nodes])
 
 


### PR DESCRIPTION
This adds Pylint 4 support. This fixes issues that come from:

1. pylint-dev/pylint#9995 - thus the `NamesConsumer` is updated directly
2. pylint-dev/astroid#2602 - Classes like `DateTimeField` and `ImageField` have their inheritance from `DateField` or `FileField` ignored and thus Pylint gives error on instantiation