### PR TITLE
Adding format-html-interpolation and mark-safe-interpolation checkers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@ Changelog
 =========
 
 
+Version 2.8.0
+-------------
+
+New checks
+~~~~~~~~~~
+
+- Added ``format-html-interpolation`` (W5150) and ``mark-safe-interpolation`` (W5151) checks
+  which warn when the format string of ``format_html()`` / ``format_html_join()`` or the
+  argument of ``mark_safe()`` is built with an f-string, ``str.format()``, ``%``-formatting or
+  ``+`` concatenation. Such values bypass Django's HTML escaping; pass them as arguments instead.
+
+
 Version 2.7.0
 -------------
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@
 - [john-sandall](https://github.com/john-sandall)
 - [dineshtrivedi](https://github.com/dineshtrivedi)
 - [matejsp](https://github.com/matejsp)
+- [joewesch](https://github.com/joewesch)

--- a/pylint_django/checkers/__init__.py
+++ b/pylint_django/checkers/__init__.py
@@ -3,6 +3,7 @@
 from pylint_django.checkers.auth_user import AuthUserChecker
 from pylint_django.checkers.django_installed import DjangoInstalledChecker
 from pylint_django.checkers.foreign_key_strings import ForeignKeyStringsChecker
+from pylint_django.checkers.format_html import FormatHtmlChecker
 from pylint_django.checkers.forms import FormChecker
 from pylint_django.checkers.json_response import JsonResponseChecker
 from pylint_django.checkers.models import ModelChecker
@@ -16,3 +17,4 @@ def register_checkers(linter):
     linter.register_checker(FormChecker(linter))
     linter.register_checker(AuthUserChecker(linter))
     linter.register_checker(ForeignKeyStringsChecker(linter))
+    linter.register_checker(FormatHtmlChecker(linter))

--- a/pylint_django/checkers/format_html.py
+++ b/pylint_django/checkers/format_html.py
@@ -1,0 +1,90 @@
+# Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint-django/blob/master/LICENSE
+"""
+Discourage building the format string of `format_html()` / `format_html_join()` and the
+argument of `mark_safe()` by interpolation or concatenation.
+
+Django's `format_html(format_string, *args, **kwargs)` HTML-escapes every argument before it is
+substituted into the format string. When the format string is instead built with an f-string,
+`str.format()`, `%`-formatting or `+` concatenation, the interpolated values are spliced in
+without escaping, which reintroduces the XSS hole `format_html()` exists to close. The same is
+true of `mark_safe()`, which performs no escaping at all.
+"""
+
+from __future__ import annotations
+
+from astroid.nodes import Attribute, BinOp, Call, Const, FormattedValue, JoinedStr
+from pylint import checkers
+from pylint.checkers.utils import only_required_for_messages
+
+from pylint_django.__pkginfo__ import BASE_ID
+
+
+def _is_interpolated_string(node):
+    """Return True when `node` is a string built by interpolation/concatenation.
+
+    A plain string literal (or an f-string without any interpolation) is safe and returns False.
+    """
+    # f-string -- only flag when it actually interpolates a value.
+    if isinstance(node, JoinedStr):
+        return any(isinstance(value, FormattedValue) for value in node.values)
+
+    if isinstance(node, BinOp):
+        # "...%s..." % value
+        if node.op == "%":
+            return True
+        # "..." + value + "..."
+        if node.op == "+":
+            operands = (node.left, node.right)
+            has_const_str = any(isinstance(op, Const) and isinstance(op.value, str) for op in operands)
+            has_dynamic = any(not isinstance(op, Const) for op in operands)
+            return has_const_str and has_dynamic
+
+    # "...{}...".format(value) or some_str.format(value)
+    if isinstance(node, Call) and isinstance(node.func, Attribute) and node.func.attrname == "format":
+        return True
+
+    return False
+
+
+class FormatHtmlChecker(checkers.BaseChecker):
+    """
+    Looks for interpolated strings passed to Django's HTML-escaping helpers, which silently
+    bypasses their auto-escaping.
+    """
+
+    # configuration section name
+    name = "format-html-checker"
+    msgs = {
+        f"W{BASE_ID}50": (
+            "Pass interpolated values as arguments to format_html() instead of building the "
+            "format string; arguments are automatically HTML-escaped",
+            "format-html-interpolation",
+            "Used when the format string of format_html()/format_html_join() is built with an "
+            "f-string, str.format(), %-formatting or + concatenation, which bypasses escaping.",
+        ),
+        f"W{BASE_ID}51": (
+            "Avoid mark_safe() on a dynamically-built string; use format_html() with arguments "
+            "so values are HTML-escaped",
+            "mark-safe-interpolation",
+            "Used when mark_safe() is called on a string built with an f-string, str.format(), "
+            "%-formatting or + concatenation, which is not escaped at all.",
+        ),
+    }
+
+    @only_required_for_messages("format-html-interpolation", "mark-safe-interpolation")
+    def visit_call(self, node):
+        func = node.func.as_string()
+
+        # Check the longer name first so format_html_join isn't swallowed by the format_html test.
+        if func.endswith("format_html_join") and len(node.args) >= 2:
+            candidate, message = node.args[1], "format-html-interpolation"
+        elif func.endswith("format_html") and node.args:
+            candidate, message = node.args[0], "format-html-interpolation"
+        elif func.endswith("mark_safe") and node.args:
+            candidate, message = node.args[0], "mark-safe-interpolation"
+        else:
+            return
+
+        if _is_interpolated_string(candidate):
+            self.add_message(message, node=node)

--- a/pylint_django/checkers/format_html.py
+++ b/pylint_django/checkers/format_html.py
@@ -9,6 +9,10 @@ substituted into the format string. When the format string is instead built with
 `str.format()`, `%`-formatting or `+` concatenation, the interpolated values are spliced in
 without escaping, which reintroduces the XSS hole `format_html()` exists to close. The same is
 true of `mark_safe()`, which performs no escaping at all.
+
+Django deprecated calling `format_html()` without arguments for exactly this reason; see
+https://code.djangoproject.com/ticket/34609 and the `format_html()` reference docs at
+https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.html.format_html
 """
 
 from __future__ import annotations
@@ -61,14 +65,16 @@ class FormatHtmlChecker(checkers.BaseChecker):
             "format string; arguments are automatically HTML-escaped",
             "format-html-interpolation",
             "Used when the format string of format_html()/format_html_join() is built with an "
-            "f-string, str.format(), %-formatting or + concatenation, which bypasses escaping.",
+            "f-string, str.format(), %-formatting or + concatenation, which bypasses escaping. "
+            "See https://code.djangoproject.com/ticket/34609",
         ),
         f"W{BASE_ID}51": (
             "Avoid mark_safe() on a dynamically-built string; use format_html() with arguments "
             "so values are HTML-escaped",
             "mark-safe-interpolation",
             "Used when mark_safe() is called on a string built with an f-string, str.format(), "
-            "%-formatting or + concatenation, which is not escaped at all.",
+            "%-formatting or + concatenation, which is not escaped at all. See "
+            "https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.html.format_html",
         ),
     }
 

--- a/pylint_django/tests/input/func_format_html.py
+++ b/pylint_django/tests/input/func_format_html.py
@@ -1,0 +1,54 @@
+# pylint: disable=missing-docstring, line-too-long, consider-using-f-string, invalid-name
+
+from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
+
+name = "world"
+rows = [("a", "b")]
+
+
+def format_html_with_fstring():
+    return format_html(f"<b>{name}</b>")  # [format-html-interpolation]
+
+
+def format_html_with_str_format():
+    return format_html("<b>{}</b>".format(name))  # [format-html-interpolation]
+
+
+def format_html_with_percent():
+    return format_html("<b>%s</b>" % name)  # [format-html-interpolation]
+
+
+def format_html_with_concat():
+    return format_html("<b>" + name + "</b>")  # [format-html-interpolation]
+
+
+def format_html_join_with_fstring():
+    return format_html_join("\n", f"<li>{name}</li>", ((row,) for row in rows))  # [format-html-interpolation]
+
+
+def mark_safe_with_fstring():
+    return mark_safe(f"<b>{name}</b>")  # [mark-safe-interpolation]
+
+
+# The following are safe and must NOT be flagged.
+
+
+def format_html_with_arguments():
+    return format_html("<b>{}</b>", name)
+
+
+def format_html_static_literal():
+    return format_html("<b>static</b>")
+
+
+def format_html_static_fstring():
+    return format_html(f"static")  # pylint: disable=f-string-without-interpolation
+
+
+def format_html_join_with_arguments():
+    return format_html_join("\n", "<li>{}</li>", ((row,) for row in rows))
+
+
+def mark_safe_static_literal():
+    return mark_safe("<b>static</b>")

--- a/pylint_django/tests/input/func_format_html.txt
+++ b/pylint_django/tests/input/func_format_html.txt
@@ -1,0 +1,6 @@
+format-html-interpolation:11:11:11:40:format_html_with_fstring:Pass interpolated values as arguments to format_html() instead of building the format string; arguments are automatically HTML-escaped:UNDEFINED
+format-html-interpolation:15:11:15:48:format_html_with_str_format:Pass interpolated values as arguments to format_html() instead of building the format string; arguments are automatically HTML-escaped:UNDEFINED
+format-html-interpolation:19:11:19:42:format_html_with_percent:Pass interpolated values as arguments to format_html() instead of building the format string; arguments are automatically HTML-escaped:UNDEFINED
+format-html-interpolation:23:11:23:45:format_html_with_concat:Pass interpolated values as arguments to format_html() instead of building the format string; arguments are automatically HTML-escaped:UNDEFINED
+format-html-interpolation:27:11:27:79:format_html_join_with_fstring:Pass interpolated values as arguments to format_html() instead of building the format string; arguments are automatically HTML-escaped:UNDEFINED
+mark-safe-interpolation:31:11:31:38:mark_safe_with_fstring:Avoid mark_safe() on a dynamically-built string; use format_html() with arguments so values are HTML-escaped:UNDEFINED


### PR DESCRIPTION
This PR adds 2 checkers that revolve around the same issue: passing interpolated strings to `format_html` or `mark_safe`. When using `format_html`, it should be treated the same as an f-string and pass the values are args or kwargs so that they are automatically escaped. By using interpolated strings directly into `format_html`, you completely bypass this safety measure.